### PR TITLE
feat: add rich queries, bulk actions, and output controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ brew install ossianhempel/tap/things3-cli
 
 - `add`              Add a new todo
 - `update`           Update an existing todo (requires auth token)
+- `delete`           Move todos to Trash (bulk capable)
+- `undo`             Undo the last bulk update/trash action
 - `add-area`         Add a new area
 - `add-project`      Add a new project
 - `update-area`      Update an existing area

--- a/internal/cli/actionlog.go
+++ b/internal/cli/actionlog.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+)
+
+type ActionType string
+
+const (
+	ActionUpdate ActionType = "update"
+	ActionTrash  ActionType = "trash"
+)
+
+type ActionEntry struct {
+	Timestamp string       `json:"timestamp"`
+	Type      ActionType   `json:"type"`
+	Items     []ActionItem `json:"items"`
+}
+
+type ActionItem struct {
+	UUID         string   `json:"uuid"`
+	Title        string   `json:"title"`
+	Status       int      `json:"status"`
+	Notes        string   `json:"notes,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	Deadline     string   `json:"deadline,omitempty"`
+	Start        string   `json:"start,omitempty"`
+	StartDate    string   `json:"start_date,omitempty"`
+	ProjectID    string   `json:"project_id,omitempty"`
+	AreaID       string   `json:"area_id,omitempty"`
+	HeadingTitle string   `json:"heading_title,omitempty"`
+}
+
+func actionLogPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "things3-cli")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(path, "actions.jsonl"), nil
+}
+
+func appendAction(entry ActionEntry) error {
+	path, err := actionLogPath()
+	if err != nil {
+		return err
+	}
+	entry.Timestamp = time.Now().Format(time.RFC3339)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	return enc.Encode(entry)
+}
+
+func readLastAction() (ActionEntry, error) {
+	path, err := actionLogPath()
+	if err != nil {
+		return ActionEntry{}, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ActionEntry{}, errors.New("no actions logged")
+		}
+		return ActionEntry{}, err
+	}
+	defer file.Close()
+
+	var lastLine string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lastLine = line
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ActionEntry{}, err
+	}
+	if lastLine == "" {
+		return ActionEntry{}, errors.New("no actions logged")
+	}
+	var entry ActionEntry
+	if err := json.Unmarshal([]byte(lastLine), &entry); err != nil {
+		return ActionEntry{}, err
+	}
+	return entry, nil
+}
+
+func removeLastAction() error {
+	path, err := actionLogPath()
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			lines = append(lines[:i], lines[i+1:]...)
+			break
+		}
+	}
+	content := strings.Join(lines, "\n")
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func taskToActionItem(task db.Task) ActionItem {
+	return ActionItem{
+		UUID:         task.UUID,
+		Title:        task.Title,
+		Status:       task.Status,
+		Notes:        task.Notes,
+		Tags:         task.Tags,
+		Deadline:     task.Deadline,
+		Start:        task.Start,
+		StartDate:    task.StartDate,
+		ProjectID:    task.ProjectID,
+		AreaID:       task.AreaID,
+		HeadingTitle: task.HeadingTitle,
+	}
+}

--- a/internal/cli/all.go
+++ b/internal/cli/all.go
@@ -25,11 +25,19 @@ func NewAllCommand(app *App) *cobra.Command {
 			}
 			defer store.Close()
 
-			incompleteFilter, err := buildTaskFilter(store, "incomplete", false, false, "", "", "", "", limit, recursive)
+			incompleteFilter, _, err := buildTaskFilter(store, TaskQueryOptions{
+				Status:           "incomplete",
+				Limit:            limit,
+				IncludeChecklist: recursive,
+			})
 			if err != nil {
 				return err
 			}
-			anyFilter, err := buildTaskFilter(store, "any", false, false, "", "", "", "", limit, recursive)
+			anyFilter, _, err := buildTaskFilter(store, TaskQueryOptions{
+				Status:           "any",
+				Limit:            limit,
+				IncludeChecklist: recursive,
+			})
 			if err != nil {
 				return err
 			}
@@ -116,7 +124,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(inbox) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, inbox, false, noHeader)
+				return printTasks(app.Out, inbox, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}
@@ -124,7 +132,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(today) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, today, false, noHeader)
+				return printTasks(app.Out, today, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}
@@ -132,7 +140,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(upcoming) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, upcoming, false, noHeader)
+				return printTasks(app.Out, upcoming, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}
@@ -140,7 +148,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(anytime) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, anytime, false, noHeader)
+				return printTasks(app.Out, anytime, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}
@@ -148,7 +156,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(someday) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, someday, false, noHeader)
+				return printTasks(app.Out, someday, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}
@@ -156,7 +164,7 @@ func NewAllCommand(app *App) *cobra.Command {
 				if len(logbook) == 0 {
 					return nil
 				}
-				return printTasks(app.Out, logbook, false, noHeader)
+				return printTasks(app.Out, logbook, TaskOutputOptions{Format: "table", NoHeader: noHeader})
 			}); err != nil {
 				return err
 			}

--- a/internal/cli/date_commands.go
+++ b/internal/cli/date_commands.go
@@ -9,16 +9,14 @@ import (
 
 func NewCreatedTodayCommand(app *App) *cobra.Command {
 	var dbPath string
-	status := "any"
-	var project string
-	var area string
-	var tag string
-	var includeTrashed bool
-	var all bool
-	var limit int
+	opts := TaskQueryOptions{
+		Status: "any",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
 	var asJSON bool
 	var noHeader bool
-	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:   "createdtoday",
@@ -30,53 +28,41 @@ func NewCreatedTodayCommand(app *App) *cobra.Command {
 			}
 			defer store.Close()
 
-			filter, err := buildTaskFilter(store, status, includeTrashed, all, project, area, tag, "", limit, recursive)
+			now := time.Now()
+			start := now.Add(-24 * time.Hour)
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
 			if err != nil {
 				return err
 			}
-
-			now := time.Now()
-			start := now.Add(-24 * time.Hour)
-			tasks, err := store.TasksCreatedBetween(start, now, filter)
+			tasks, err := fetchTasks(store, func(filter db.TaskFilter) ([]db.Task, error) {
+				return store.TasksCreatedBetween(start, now, filter)
+			}, opts, false, []int{db.TaskTypeTodo})
 			if err != nil {
 				return formatDBError(err)
 			}
-			return printTasks(app.Out, tasks, asJSON, noHeader)
+			return printTasks(app.Out, tasks, outputOpts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
-	cmd.Flags().StringVar(&status, "status", status, "Filter by status: incomplete, completed, canceled, any")
-	cmd.Flags().StringVarP(&project, "filter-project", "p", "", "Filter by project title or ID")
-	cmd.Flags().StringVar(&project, "project", "", "Alias for --filter-project")
-	cmd.Flags().StringVarP(&area, "filter-area", "a", "", "Filter by area title or ID")
-	cmd.Flags().StringVar(&area, "area", "", "Alias for --filter-area")
-	cmd.Flags().StringVarP(&tag, "filter-tag", "t", "", "Filter by tag title or ID")
-	cmd.Flags().StringVar(&tag, "filtertag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&tag, "tag", "", "Alias for --filter-tag")
-	cmd.Flags().IntVar(&limit, "limit", 200, "Limit number of results (0 = no limit)")
-	cmd.Flags().BoolVar(&includeTrashed, "include-trashed", false, "Include trashed tasks")
-	cmd.Flags().BoolVar(&all, "all", false, "Include completed, canceled, and trashed tasks")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include checklist items in JSON output")
-	cmd.Flags().BoolVarP(&asJSON, "json", "j", false, "Output JSON")
-	cmd.Flags().BoolVar(&noHeader, "no-header", false, "Suppress header row")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
 
 	return cmd
 }
 
 func NewLogTodayCommand(app *App) *cobra.Command {
 	var dbPath string
-	status := "any"
-	var project string
-	var area string
-	var tag string
-	var includeTrashed bool
-	var all bool
-	var limit int
+	opts := TaskQueryOptions{
+		Status: "any",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
 	var asJSON bool
 	var noHeader bool
-	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:   "logtoday",
@@ -88,36 +74,26 @@ func NewLogTodayCommand(app *App) *cobra.Command {
 			}
 			defer store.Close()
 
-			filter, err := buildTaskFilter(store, status, includeTrashed, all, project, area, tag, "", limit, recursive)
+			start, end := dayBounds()
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
 			if err != nil {
 				return err
 			}
-
-			start, end := dayBounds()
-			tasks, err := store.TasksCompletedBetween(start, end, filter)
+			tasks, err := fetchTasks(store, func(filter db.TaskFilter) ([]db.Task, error) {
+				return store.TasksCompletedBetween(start, end, filter)
+			}, opts, false, []int{db.TaskTypeTodo})
 			if err != nil {
 				return formatDBError(err)
 			}
-			return printTasks(app.Out, tasks, asJSON, noHeader)
+			return printTasks(app.Out, tasks, outputOpts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
-	cmd.Flags().StringVar(&status, "status", status, "Filter by status: incomplete, completed, canceled, any")
-	cmd.Flags().StringVarP(&project, "filter-project", "p", "", "Filter by project title or ID")
-	cmd.Flags().StringVar(&project, "project", "", "Alias for --filter-project")
-	cmd.Flags().StringVarP(&area, "filter-area", "a", "", "Filter by area title or ID")
-	cmd.Flags().StringVar(&area, "area", "", "Alias for --filter-area")
-	cmd.Flags().StringVarP(&tag, "filter-tag", "t", "", "Filter by tag title or ID")
-	cmd.Flags().StringVar(&tag, "filtertag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&tag, "tag", "", "Alias for --filter-tag")
-	cmd.Flags().IntVar(&limit, "limit", 200, "Limit number of results (0 = no limit)")
-	cmd.Flags().BoolVar(&includeTrashed, "include-trashed", false, "Include trashed tasks")
-	cmd.Flags().BoolVar(&all, "all", false, "Include completed, canceled, and trashed tasks")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include checklist items in JSON output")
-	cmd.Flags().BoolVarP(&asJSON, "json", "j", false, "Output JSON")
-	cmd.Flags().BoolVar(&noHeader, "no-header", false, "Suppress header row")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
 
 	return cmd
 }

--- a/internal/cli/dboutput.go
+++ b/internal/cli/dboutput.go
@@ -59,24 +59,12 @@ func printTags(out io.Writer, tags []db.Tag, asJSON bool, noHeader bool) error {
 	return w.Flush()
 }
 
-func printTasks(out io.Writer, tasks []db.Task, asJSON bool, noHeader bool) error {
-	if asJSON {
-		enc := json.NewEncoder(out)
-		return enc.Encode(tasks)
-	}
-	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	if !noHeader {
-		fmt.Fprintln(w, "UUID\tTITLE\tPROJECT\tAREA\tHEADING\tSTATUS\tTRASHED")
-	}
-	for _, t := range tasks {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%t\n",
-			t.UUID, t.Title, t.ProjectTitle, t.AreaTitle, t.HeadingTitle, db.StatusLabel(t.Status), t.Trashed)
-	}
-	return w.Flush()
+func printTasks(out io.Writer, tasks []db.Task, opts TaskOutputOptions) error {
+	return writeTasks(out, tasks, opts)
 }
 
-func printTaskSections(out io.Writer, sections []TaskSection, asJSON bool, noHeader bool) error {
-	if asJSON {
+func printTaskSections(out io.Writer, sections []TaskSection, opts TaskOutputOptions) error {
+	if opts.Format == "json" {
 		enc := json.NewEncoder(out)
 		return enc.Encode(sections)
 	}
@@ -88,7 +76,7 @@ func printTaskSections(out io.Writer, sections []TaskSection, asJSON bool, noHea
 		if len(section.Items) == 0 {
 			continue
 		}
-		if err := printTasks(out, section.Items, false, noHeader); err != nil {
+		if err := printTasks(out, section.Items, TaskOutputOptions{Format: "table", NoHeader: opts.NoHeader, Select: opts.Select}); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+	"github.com/ossianhempel/things3-cli/internal/things"
+	"github.com/spf13/cobra"
+)
+
+// NewDeleteCommand builds the delete subcommand.
+func NewDeleteCommand(app *App) *cobra.Command {
+	var dbPath string
+	var id string
+	var yes bool
+	opts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Move todos to Trash",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, _, err := db.OpenDefault(dbPath)
+			if err != nil {
+				return formatDBError(err)
+			}
+			defer store.Close()
+
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			changedStatus := cmd.Flags().Changed("status")
+
+			var tasks []db.Task
+			if strings.TrimSpace(id) != "" {
+				if hasExplicitSelector(map[string]bool{"status": changedStatus}, opts) {
+					return fmt.Errorf("Error: use either --id or query filters")
+				}
+				task, err := store.TaskByID(id)
+				if err != nil {
+					return formatDBError(err)
+				}
+				tasks = []db.Task{*task}
+			} else {
+				if !hasExplicitSelector(map[string]bool{"status": changedStatus}, opts) {
+					return fmt.Errorf("Error: refuse to delete without a selector (use --query/--search/--tag/etc)")
+				}
+				tasks, err = fetchTasks(store, store.Tasks, opts, false, []int{db.TaskTypeTodo})
+				if err != nil {
+					return formatDBError(err)
+				}
+			}
+
+			if len(tasks) == 0 {
+				return fmt.Errorf("Error: no tasks matched")
+			}
+
+			if app.DryRun {
+				return previewTasks(app.Out, tasks)
+			}
+
+			if len(tasks) > 1 && !yes {
+				return fmt.Errorf("Error: %d tasks matched (rerun with --yes to apply)", len(tasks))
+			}
+
+			entry := ActionEntry{
+				Type:  ActionTrash,
+				Items: make([]ActionItem, 0, len(tasks)),
+			}
+			for _, task := range tasks {
+				entry.Items = append(entry.Items, taskToActionItem(task))
+			}
+			if err := appendAction(entry); err != nil {
+				fmt.Fprintf(app.Err, "Warning: failed to write action log: %v\n", err)
+			}
+
+			ids := make([]string, 0, len(tasks))
+			for _, task := range tasks {
+				ids = append(ids, task.UUID)
+			}
+			script, err := things.BuildTrashScript(ids)
+			if err != nil {
+				return err
+			}
+			return runScript(app, script)
+		},
+	}
+
+	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
+	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
+	cmd.Flags().StringVar(&id, "id", "", "ID of the todo to delete")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Confirm bulk delete")
+	addTaskQueryFlags(cmd, &opts, true, true)
+
+	return cmd
+}

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -14,6 +14,8 @@ DESCRIPTION
 COMMANDS
   add            - add new todo
   update         - update exiting todo
+  delete         - move todos to Trash
+  undo           - undo the last bulk action
   add-area       - add new area
   add-project    - add new project
   update-area    - update exiting area
@@ -224,8 +226,38 @@ OPTIONS
   --search=TEXT
     Case-insensitive substring match on title or notes.
 
+  --query=EXPR
+    Rich query with boolean ops, fields, and regex (e.g. title:/regex/ AND tag:reading).
+
+  --created-before=DATE
+    Filter tasks created before DATE (YYYY-MM-DD or RFC3339).
+
+  --created-after=DATE
+    Filter tasks created after DATE (YYYY-MM-DD or RFC3339).
+
+  --modified-before=DATE
+    Filter tasks modified before DATE (YYYY-MM-DD or RFC3339).
+
+  --modified-after=DATE
+    Filter tasks modified after DATE (YYYY-MM-DD or RFC3339).
+
+  --due-before=DATE
+    Filter tasks due before DATE (YYYY-MM-DD).
+
+  --start-before=DATE
+    Filter tasks scheduled before DATE (YYYY-MM-DD).
+
+  --has-url
+    Filter tasks with URLs in notes.
+
   --limit=N
     Limit number of results (0 = no limit). Default: 200.
+
+  --offset=N
+    Offset results for pagination.
+
+  --sort=FIELDS
+    Sort by fields (e.g. created,-deadline,title).
 
   --recursive
     Include checklist items in JSON output.
@@ -236,8 +268,14 @@ OPTIONS
   --all
     Include completed, canceled, and trashed tasks.
 
+  --format=FORMAT
+    Output format: table, json, jsonl, csv.
+
+  --select=FIELDS
+    Select fields (comma-separated).
+
   --json
-    Output JSON.
+    Output JSON (alias for --format json).
 
   --no-header
     Suppress the header row.
@@ -258,6 +296,7 @@ SYNOPSIS
 DESCRIPTION
   Lists tasks that should appear in Today using the local Things database.
   This mirrors the Things logic for today (including predicted items).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -309,6 +348,7 @@ SYNOPSIS
 DESCRIPTION
   Lists tasks that are in the Inbox list (unfiled) using the local Things
   database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -360,6 +400,7 @@ SYNOPSIS
 DESCRIPTION
   Lists tasks scheduled in the future using the local Things database
   (read-only). Tasks with only deadlines are not included.
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -411,6 +452,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists tasks in Anytime using the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -462,6 +504,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists tasks in Someday using the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -514,6 +557,7 @@ SYNOPSIS
 DESCRIPTION
   Lists completed and canceled tasks from the local Things database
   (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -566,6 +610,7 @@ SYNOPSIS
 DESCRIPTION
   Lists tasks completed or canceled today using the local Things database
   (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -617,6 +662,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists tasks created today using the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -668,6 +714,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists completed tasks from the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -719,6 +766,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists canceled tasks from the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -770,6 +818,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists trashed tasks from the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -821,6 +870,7 @@ SYNOPSIS
 
 DESCRIPTION
   Lists tasks with deadlines using the local Things database (read-only).
+  Supports the same filters and output controls as {{BT}}things tasks{{BT}}.
 
 OPTIONS
   --db=PATH
@@ -1153,7 +1203,7 @@ SYNOPSIS
 
 DESCRIPTION
   Searches tasks in the local Things database by title or notes. Query is
-  required.
+  required. Use --query for rich boolean/regex syntax.
 
   If {{BT}}-{{BT}} is given as a query, it is read from STDIN.
 
@@ -1173,8 +1223,38 @@ OPTIONS
   --tag=TAG
     Filter by tag title or ID.
 
-  --limit=COUNT
-    Limit the number of results. 0 means no limit. Default: 200.
+  --query=EXPR
+    Rich query with boolean ops, fields, and regex (e.g. title:/regex/ AND tag:reading).
+
+  --created-before=DATE
+    Filter tasks created before DATE (YYYY-MM-DD or RFC3339).
+
+  --created-after=DATE
+    Filter tasks created after DATE (YYYY-MM-DD or RFC3339).
+
+  --modified-before=DATE
+    Filter tasks modified before DATE (YYYY-MM-DD or RFC3339).
+
+  --modified-after=DATE
+    Filter tasks modified after DATE (YYYY-MM-DD or RFC3339).
+
+  --due-before=DATE
+    Filter tasks due before DATE (YYYY-MM-DD).
+
+  --start-before=DATE
+    Filter tasks scheduled before DATE (YYYY-MM-DD).
+
+  --has-url
+    Filter tasks with URLs in notes.
+
+  --limit=N
+    Limit number of results (0 = no limit). Default: 200.
+
+  --offset=N
+    Offset results for pagination.
+
+  --sort=FIELDS
+    Sort by fields (e.g. created,-deadline,title).
 
   --recursive
     Include checklist items in JSON output.
@@ -1185,8 +1265,14 @@ OPTIONS
   --all
     Include completed, canceled, and trashed tasks.
 
+  --format=FORMAT
+    Output format: table, json, jsonl, csv.
+
+  --select=FIELDS
+    Select fields (comma-separated).
+
   --json
-    Output JSON.
+    Output JSON (alias for --format json).
 
   --no-header
     Suppress the header row.
@@ -1210,7 +1296,10 @@ SYNOPSIS
   things update [OPTIONS...] [--] [-|TITLE]
 
 DESCRIPTION
-  Updates an existing todo identified by {{BT}}--id={{BT}}.
+  Updates an existing todo identified by {{BT}}--id={{BT}}. To update multiple
+  todos, omit {{BT}}--id={{BT}} and provide query filters (same as
+  {{BT}}things tasks{{BT}}). Use {{BT}}--yes{{BT}} to confirm bulk updates;
+  {{BT}}--dry-run{{BT}} shows a preview.
 
   If {{BT}}-{{BT}} is given as a title, it is read from STDIN. When titles have
   multiple lines of text, the first is set as the todo's title and the
@@ -1230,12 +1319,18 @@ AUTHORIZATION
     3. Copy the token (or enable "Allow 'things' CLI to access Things").
 
 OPTIONS
+  --db=PATH
+    Path to the Things database. Overrides the THINGSDB environment variable.
+
   --auth-token=TOKEN
     The Things URL scheme authorization token. Required. See below for more
     information on authorization. If not provided, uses THINGS_AUTH_TOKEN.
 
   --id=ID
-    The ID of the todo to update. Required.
+    The ID of the todo to update. Required for single updates.
+
+  --yes
+    Confirm bulk update.
 
   --notes=NOTES
     The notes of the todo. This will replace the existing notes. Maximum
@@ -1356,6 +1451,53 @@ EXAMPLES
 
 SEE ALSO
   Authorization: https://culturedcode.com/things/support/articles/2803573/#overview-authorization
+`
+
+const deleteHelp = `Usage: things delete [OPTIONS...]
+
+NAME
+  things delete - move todos to Trash
+
+SYNOPSIS
+  things delete [OPTIONS...]
+
+DESCRIPTION
+  Moves todos to Trash using AppleScript. Provide {{BT}}--id={{BT}} for a single
+  todo or use query filters (same as {{BT}}things tasks{{BT}}) for bulk delete.
+  Use {{BT}}--dry-run{{BT}} to preview matches and {{BT}}--yes{{BT}} to confirm
+  bulk actions.
+
+OPTIONS
+  --db=PATH
+    Path to the Things database. Overrides the THINGSDB environment variable.
+
+  --id=ID
+    The ID of the todo to delete. Takes precedence over query filters.
+
+  --yes
+    Confirm bulk delete.
+`
+
+const undoHelp = `Usage: things undo [OPTIONS...]
+
+NAME
+  things undo - undo the last bulk action
+
+SYNOPSIS
+  things undo [OPTIONS...]
+
+DESCRIPTION
+  Replays the last bulk update or trash action recorded by things3-cli.
+  Undoing updates requires a Things URL scheme token. Undoing trash recreates
+  tasks as new items.
+
+OPTIONS
+  --auth-token=TOKEN
+    The Things URL scheme authorization token. If not provided, uses
+    THINGS_AUTH_TOKEN.
+
+  --yes
+    Confirm undo for multiple tasks.
 `
 
 const updateAreaHelp = `Usage: things update-area [OPTIONS...] [--] [-|TITLE]

--- a/internal/cli/preview.go
+++ b/internal/cli/preview.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+)
+
+const previewLimit = 20
+
+func previewTasks(out io.Writer, tasks []db.Task) error {
+	count := len(tasks)
+	fmt.Fprintf(out, "Matches: %d\n", count)
+	if count == 0 {
+		return nil
+	}
+	preview := tasks
+	if count > previewLimit {
+		preview = tasks[:previewLimit]
+		fmt.Fprintf(out, "Preview (first %d):\n", previewLimit)
+	} else {
+		fmt.Fprintln(out, "Preview:")
+	}
+	return printTasks(out, preview, TaskOutputOptions{Format: "table"})
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,6 +57,8 @@ func NewRoot(app *App) *cobra.Command {
 	cmd.AddCommand(NewUpdateCommand(app))
 	cmd.AddCommand(NewUpdateAreaCommand(app))
 	cmd.AddCommand(NewUpdateProjectCommand(app))
+	cmd.AddCommand(NewDeleteCommand(app))
+	cmd.AddCommand(NewUndoCommand(app))
 	cmd.AddCommand(NewShowCommand(app))
 	cmd.AddCommand(NewSearchCommand(app))
 
@@ -123,6 +125,10 @@ func NewRoot(app *App) *cobra.Command {
 				printHelp(app.Out, formatHelpText(updateAreaHelp, isTTY(app.Out)))
 			case "update-project":
 				printHelp(app.Out, formatHelpText(updateProjectHelp, isTTY(app.Out)))
+			case "delete":
+				printHelp(app.Out, formatHelpText(deleteHelp, isTTY(app.Out)))
+			case "undo":
+				printHelp(app.Out, formatHelpText(undoHelp, isTTY(app.Out)))
 			case "help":
 				printHelp(app.Out, formatHelpText(rootHelp, isTTY(app.Out)))
 			default:
@@ -193,6 +199,10 @@ func NewRoot(app *App) *cobra.Command {
 			printHelp(app.Out, formatHelpText(updateAreaHelp, isTTY(app.Out)))
 		case "update-project":
 			printHelp(app.Out, formatHelpText(updateProjectHelp, isTTY(app.Out)))
+		case "delete":
+			printHelp(app.Out, formatHelpText(deleteHelp, isTTY(app.Out)))
+		case "undo":
+			printHelp(app.Out, formatHelpText(undoHelp, isTTY(app.Out)))
 		default:
 			printHelp(app.Out, formatHelpText(rootHelp, isTTY(app.Out)))
 		}

--- a/internal/cli/taskfilter.go
+++ b/internal/cli/taskfilter.go
@@ -2,53 +2,244 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/ossianhempel/things3-cli/internal/db"
 )
 
-func buildTaskFilter(store *db.Store, status string, includeTrashed bool, all bool, project string, area string, tag string, search string, limit int, includeChecklist bool) (db.TaskFilter, error) {
-	statusFilter, err := db.ParseStatus(status)
+type TaskQueryOptions struct {
+	Status           string
+	IncludeTrashed   bool
+	All              bool
+	Project          string
+	Area             string
+	Tag              string
+	Search           string
+	Query            string
+	Limit            int
+	Offset           int
+	IncludeChecklist bool
+	CreatedBefore    string
+	CreatedAfter     string
+	ModifiedBefore   string
+	ModifiedAfter    string
+	DueBefore        string
+	StartBefore      string
+	HasURL           bool
+	HasURLSet        bool
+	Sort             string
+}
+
+type TaskSortField struct {
+	Field string
+	Desc  bool
+}
+
+func buildTaskFilter(store *db.Store, opts TaskQueryOptions) (db.TaskFilter, []TaskSortField, error) {
+	statusFilter, err := db.ParseStatus(opts.Status)
 	if err != nil {
-		return db.TaskFilter{}, fmt.Errorf("Error: %s", err)
+		return db.TaskFilter{}, nil, fmt.Errorf("Error: %s", err)
 	}
-	if all {
+	includeTrashed := opts.IncludeTrashed
+	if opts.All {
 		statusFilter = nil
 		includeTrashed = true
 	}
 
 	projectID := ""
-	if project != "" {
-		projectID, err = store.ResolveProjectID(project)
+	if opts.Project != "" {
+		projectID, err = store.ResolveProjectID(opts.Project)
 		if err != nil {
-			return db.TaskFilter{}, fmt.Errorf("Error: %s", err)
+			return db.TaskFilter{}, nil, fmt.Errorf("Error: %s", err)
 		}
 	}
 
 	areaID := ""
-	if area != "" {
-		areaID, err = store.ResolveAreaID(area)
+	if opts.Area != "" {
+		areaID, err = store.ResolveAreaID(opts.Area)
 		if err != nil {
-			return db.TaskFilter{}, fmt.Errorf("Error: %s", err)
+			return db.TaskFilter{}, nil, fmt.Errorf("Error: %s", err)
 		}
 	}
 
 	tagID := ""
-	if tag != "" {
-		tagID, err = store.ResolveTagID(tag)
+	if opts.Tag != "" {
+		tagID, err = store.ResolveTagID(opts.Tag)
 		if err != nil {
-			return db.TaskFilter{}, fmt.Errorf("Error: %s", err)
+			return db.TaskFilter{}, nil, fmt.Errorf("Error: %s", err)
 		}
 	}
 
-	return db.TaskFilter{
-		Status:           statusFilter,
-		IncludeTrashed:   includeTrashed,
+	sortFields, orderClause, err := parseSortSpec(opts.Sort)
+	if err != nil {
+		return db.TaskFilter{}, nil, err
+	}
+
+	filter := db.TaskFilter{
+		Status:                statusFilter,
+		IncludeTrashed:        includeTrashed,
 		ExcludeTrashedContext: true,
-		ProjectID:        projectID,
-		AreaID:           areaID,
-		TagID:            tagID,
-		Search:           search,
-		Limit:            limit,
-		IncludeChecklist: includeChecklist,
-	}, nil
+		ProjectID:             projectID,
+		AreaID:                areaID,
+		TagID:                 tagID,
+		Search:                opts.Search,
+		Limit:                 opts.Limit,
+		Offset:                opts.Offset,
+		IncludeChecklist:      opts.IncludeChecklist,
+		Order:                 orderClause,
+	}
+
+	if opts.CreatedAfter != "" {
+		value, err := parseTimestampBound(opts.CreatedAfter, false)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.CreatedAfter = &value
+	}
+	if opts.CreatedBefore != "" {
+		value, err := parseTimestampBound(opts.CreatedBefore, true)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.CreatedBefore = &value
+	}
+	if opts.ModifiedAfter != "" {
+		value, err := parseTimestampBound(opts.ModifiedAfter, false)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.ModifiedAfter = &value
+	}
+	if opts.ModifiedBefore != "" {
+		value, err := parseTimestampBound(opts.ModifiedBefore, true)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.ModifiedBefore = &value
+	}
+	if opts.DueBefore != "" {
+		value, err := parseThingsDate(opts.DueBefore)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.DueBefore = &value
+	}
+	if opts.StartBefore != "" {
+		value, err := parseThingsDate(opts.StartBefore)
+		if err != nil {
+			return db.TaskFilter{}, nil, err
+		}
+		filter.StartBefore = &value
+	}
+	if opts.HasURLSet {
+		filter.HasURL = &opts.HasURL
+	}
+
+	return filter, sortFields, nil
+}
+
+func parseTimestampBound(input string, isBefore bool) (float64, error) {
+	parsed, dateOnly, err := parseDateOrTime(input)
+	if err != nil {
+		return 0, err
+	}
+	if dateOnly && isBefore {
+		parsed = parsed.AddDate(0, 0, 1)
+	}
+	return float64(parsed.Unix()), nil
+}
+
+func parseThingsDate(input string) (int, error) {
+	parsed, _, err := parseDateOrTime(input)
+	if err != nil {
+		return 0, err
+	}
+	return thingsDateValue(parsed.In(time.Local)), nil
+}
+
+func parseDateOrTime(input string) (time.Time, bool, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return time.Time{}, false, fmt.Errorf("Error: date required")
+	}
+	if t, err := time.Parse(time.RFC3339Nano, input); err == nil {
+		return t, false, nil
+	}
+	if t, err := time.Parse(time.RFC3339, input); err == nil {
+		return t, false, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04:05", input, time.Local); err == nil {
+		return t, false, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04", input, time.Local); err == nil {
+		return t, false, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", input, time.Local); err == nil {
+		return t, true, nil
+	}
+	return time.Time{}, false, fmt.Errorf("Error: invalid date %q (use YYYY-MM-DD or RFC3339)", input)
+}
+
+func thingsDateValue(t time.Time) int {
+	date := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return date.Year()<<16 | int(date.Month())<<12 | date.Day()<<7
+}
+
+func parseSortSpec(spec string) ([]TaskSortField, string, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, "", nil
+	}
+	parts := strings.Split(spec, ",")
+	fields := make([]TaskSortField, 0, len(parts))
+	orderParts := make([]string, 0, len(parts))
+	for _, raw := range parts {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		desc := false
+		if strings.HasPrefix(raw, "-") {
+			desc = true
+			raw = strings.TrimSpace(strings.TrimPrefix(raw, "-"))
+		}
+		name := strings.ToLower(raw)
+		if alias, ok := taskSortAliases[name]; ok {
+			name = alias
+		}
+		orderExpr, ok := taskSortOrder[name]
+		if !ok {
+			return nil, "", fmt.Errorf("Error: invalid sort field %q", raw)
+		}
+		dir := " ASC"
+		if desc {
+			dir = " DESC"
+		}
+		orderParts = append(orderParts, orderExpr+dir)
+		fields = append(fields, TaskSortField{Field: name, Desc: desc})
+	}
+	return fields, strings.Join(orderParts, ", "), nil
+}
+
+var taskSortAliases = map[string]string{
+	"due":         "deadline",
+	"proj":        "project",
+	"today-index": "today_idx",
+	"today_index": "today_idx",
+}
+
+var taskSortOrder = map[string]string{
+	"created":   "t.creationDate",
+	"modified":  "t.userModificationDate",
+	"deadline":  "t.deadline",
+	"start":     "t.startDate",
+	"title":     "t.title COLLATE NOCASE",
+	"project":   "p.title COLLATE NOCASE",
+	"area":      "a.title COLLATE NOCASE",
+	"heading":   "h.title COLLATE NOCASE",
+	"status":    "t.status",
+	"uuid":      "t.uuid",
+	"index":     "t.\"index\"",
+	"today_idx": "t.todayIndex",
 }

--- a/internal/cli/taskflags.go
+++ b/internal/cli/taskflags.go
@@ -1,0 +1,42 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func addTaskQueryFlags(cmd *cobra.Command, opts *TaskQueryOptions, includeSearch bool, includeQuery bool) {
+	flags := cmd.Flags()
+	flags.StringVar(&opts.Status, "status", opts.Status, "Filter by status: incomplete, completed, canceled, any")
+	flags.StringVarP(&opts.Project, "filter-project", "p", "", "Filter by project title or ID")
+	flags.StringVar(&opts.Project, "project", "", "Alias for --filter-project")
+	flags.StringVarP(&opts.Area, "filter-area", "a", "", "Filter by area title or ID")
+	flags.StringVar(&opts.Area, "area", "", "Alias for --filter-area")
+	flags.StringVarP(&opts.Tag, "filter-tag", "t", "", "Filter by tag title or ID")
+	flags.StringVar(&opts.Tag, "filtertag", "", "Alias for --filter-tag")
+	flags.StringVar(&opts.Tag, "tag", "", "Alias for --filter-tag")
+	if includeSearch {
+		flags.StringVar(&opts.Search, "search", "", "Search title or notes (case-insensitive substring)")
+	}
+	if includeQuery {
+		flags.StringVar(&opts.Query, "query", "", "Rich query (boolean, fields, regex; e.g. title:/regex/ AND tag:reading)")
+	}
+	flags.IntVar(&opts.Limit, "limit", opts.Limit, "Limit number of results (0 = no limit)")
+	flags.IntVar(&opts.Offset, "offset", 0, "Offset results for pagination")
+	flags.BoolVar(&opts.IncludeTrashed, "include-trashed", false, "Include trashed tasks")
+	flags.BoolVar(&opts.All, "all", false, "Include completed, canceled, and trashed tasks")
+	flags.BoolVarP(&opts.IncludeChecklist, "recursive", "r", false, "Include checklist items in JSON output")
+	flags.StringVar(&opts.CreatedBefore, "created-before", "", "Filter tasks created before (YYYY-MM-DD or RFC3339)")
+	flags.StringVar(&opts.CreatedAfter, "created-after", "", "Filter tasks created after (YYYY-MM-DD or RFC3339)")
+	flags.StringVar(&opts.ModifiedBefore, "modified-before", "", "Filter tasks modified before (YYYY-MM-DD or RFC3339)")
+	flags.StringVar(&opts.ModifiedAfter, "modified-after", "", "Filter tasks modified after (YYYY-MM-DD or RFC3339)")
+	flags.StringVar(&opts.DueBefore, "due-before", "", "Filter tasks due before (YYYY-MM-DD)")
+	flags.StringVar(&opts.StartBefore, "start-before", "", "Filter tasks starting before (YYYY-MM-DD)")
+	flags.BoolVar(&opts.HasURL, "has-url", false, "Filter tasks with URLs in notes")
+	flags.StringVar(&opts.Sort, "sort", "", "Sort by fields (e.g. created,-deadline,title)")
+}
+
+func addTaskOutputFlags(cmd *cobra.Command, format *string, selectRaw *string, asJSON *bool, noHeader *bool) {
+	flags := cmd.Flags()
+	flags.StringVar(format, "format", "", "Output format: table, json, jsonl, csv")
+	flags.StringVar(selectRaw, "select", "", "Select fields (comma-separated)")
+	flags.BoolVarP(asJSON, "json", "j", false, "Output JSON (alias for --format json)")
+	flags.BoolVar(noHeader, "no-header", false, "Suppress header row")
+}

--- a/internal/cli/tasklist.go
+++ b/internal/cli/tasklist.go
@@ -9,16 +9,14 @@ type taskListRunner func(store *db.Store, filter db.TaskFilter) ([]db.Task, erro
 
 func newTaskListCommand(app *App, use string, short string, defaultStatus string, runner taskListRunner) *cobra.Command {
 	var dbPath string
-	status := defaultStatus
-	var project string
-	var area string
-	var tag string
-	var includeTrashed bool
-	var all bool
-	var limit int
+	opts := TaskQueryOptions{
+		Status: defaultStatus,
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
 	var asJSON bool
 	var noHeader bool
-	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:   use,
@@ -30,35 +28,25 @@ func newTaskListCommand(app *App, use string, short string, defaultStatus string
 			}
 			defer store.Close()
 
-			filter, err := buildTaskFilter(store, status, includeTrashed, all, project, area, tag, "", limit, recursive)
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
 			if err != nil {
 				return err
 			}
-
-			tasks, err := runner(store, filter)
+			tasks, err := fetchTasks(store, func(filter db.TaskFilter) ([]db.Task, error) {
+				return runner(store, filter)
+			}, opts, false, []int{db.TaskTypeTodo})
 			if err != nil {
 				return formatDBError(err)
 			}
-			return printTasks(app.Out, tasks, asJSON, noHeader)
+			return printTasks(app.Out, tasks, outputOpts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
-	cmd.Flags().StringVar(&status, "status", defaultStatus, "Filter by status: incomplete, completed, canceled, any")
-	cmd.Flags().StringVarP(&project, "filter-project", "p", "", "Filter by project title or ID")
-	cmd.Flags().StringVar(&project, "project", "", "Alias for --filter-project")
-	cmd.Flags().StringVarP(&area, "filter-area", "a", "", "Filter by area title or ID")
-	cmd.Flags().StringVar(&area, "area", "", "Alias for --filter-area")
-	cmd.Flags().StringVarP(&tag, "filter-tag", "t", "", "Filter by tag title or ID")
-	cmd.Flags().StringVar(&tag, "filtertag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&tag, "tag", "", "Alias for --filter-tag")
-	cmd.Flags().IntVar(&limit, "limit", 200, "Limit number of results (0 = no limit)")
-	cmd.Flags().BoolVar(&includeTrashed, "include-trashed", false, "Include trashed tasks")
-	cmd.Flags().BoolVar(&all, "all", false, "Include completed, canceled, and trashed tasks")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include checklist items in JSON output")
-	cmd.Flags().BoolVarP(&asJSON, "json", "j", false, "Output JSON")
-	cmd.Flags().BoolVar(&noHeader, "no-header", false, "Suppress header row")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
 
 	return cmd
 }

--- a/internal/cli/taskoutput.go
+++ b/internal/cli/taskoutput.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+)
+
+type TaskOutputOptions struct {
+	Format   string
+	Select   []string
+	NoHeader bool
+}
+
+func resolveTaskOutputOptions(format string, asJSON bool, selectRaw string, noHeader bool) (TaskOutputOptions, error) {
+	format = strings.TrimSpace(strings.ToLower(format))
+	if format == "" {
+		if asJSON {
+			format = "json"
+		} else {
+			format = "table"
+		}
+	} else if asJSON && format != "json" {
+		return TaskOutputOptions{}, fmt.Errorf("Error: --json cannot be used with --format %s", format)
+	}
+	switch format {
+	case "table", "json", "jsonl", "csv":
+	default:
+		return TaskOutputOptions{}, fmt.Errorf("Error: invalid format %q", format)
+	}
+	selectFields, err := parseTaskSelect(selectRaw)
+	if err != nil {
+		return TaskOutputOptions{}, err
+	}
+	return TaskOutputOptions{
+		Format:   format,
+		Select:   selectFields,
+		NoHeader: noHeader,
+	}, nil
+}
+
+func parseTaskSelect(input string) ([]string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, nil
+	}
+	parts := strings.Split(input, ",")
+	fields := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, raw := range parts {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		name := normalizeTaskField(raw)
+		if name == "" {
+			return nil, fmt.Errorf("Error: invalid select field %q (allowed: %s)", raw, strings.Join(sortedTaskFields(), ", "))
+		}
+		if !seen[name] {
+			seen[name] = true
+			fields = append(fields, name)
+		}
+	}
+	return fields, nil
+}
+
+func normalizeTaskField(raw string) string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	if name == "" {
+		return ""
+	}
+	if alias, ok := taskFieldAliases[name]; ok {
+		name = alias
+	}
+	if _, ok := taskFieldHeaders[name]; !ok {
+		return ""
+	}
+	return name
+}
+
+var taskFieldAliases = map[string]string{
+	"project_title": "project",
+	"area_title":    "area",
+	"heading_title": "heading",
+	"status_label":  "status_label",
+	"todayindex":    "today_index",
+	"today-index":   "today_index",
+	"today_index":   "today_index",
+}
+
+var taskFieldHeaders = map[string]string{
+	"uuid":         "UUID",
+	"title":        "TITLE",
+	"project":      "PROJECT",
+	"project_id":   "PROJECT_ID",
+	"area":         "AREA",
+	"area_id":      "AREA_ID",
+	"heading":      "HEADING",
+	"heading_id":   "HEADING_ID",
+	"status":       "STATUS",
+	"status_label": "STATUS_LABEL",
+	"trashed":      "TRASHED",
+	"notes":        "NOTES",
+	"start":        "START",
+	"start_date":   "START_DATE",
+	"deadline":     "DEADLINE",
+	"stop_date":    "STOP_DATE",
+	"created":      "CREATED",
+	"modified":     "MODIFIED",
+	"index":        "INDEX",
+	"today_index":  "TODAY_INDEX",
+	"tags":         "TAGS",
+	"type":         "TYPE",
+}
+
+var defaultTaskTableFields = []string{
+	"uuid",
+	"title",
+	"project",
+	"area",
+	"heading",
+	"status",
+	"trashed",
+}
+
+func taskFieldValue(task db.Task, field string) any {
+	switch field {
+	case "uuid":
+		return task.UUID
+	case "title":
+		return task.Title
+	case "project":
+		return task.ProjectTitle
+	case "project_id":
+		return task.ProjectID
+	case "area":
+		return task.AreaTitle
+	case "area_id":
+		return task.AreaID
+	case "heading":
+		return task.HeadingTitle
+	case "heading_id":
+		return task.HeadingID
+	case "status":
+		return task.Status
+	case "status_label":
+		return db.StatusLabel(task.Status)
+	case "trashed":
+		return task.Trashed
+	case "notes":
+		return task.Notes
+	case "start":
+		return task.Start
+	case "start_date":
+		return task.StartDate
+	case "deadline":
+		return task.Deadline
+	case "stop_date":
+		return task.StopDate
+	case "created":
+		return task.Created
+	case "modified":
+		return task.Modified
+	case "index":
+		return task.Index
+	case "today_index":
+		if task.TodayIndex == nil {
+			return nil
+		}
+		return *task.TodayIndex
+	case "tags":
+		return task.Tags
+	case "type":
+		return task.Type
+	default:
+		return ""
+	}
+}
+
+func taskFieldString(task db.Task, field string) string {
+	switch field {
+	case "status":
+		return db.StatusLabel(task.Status)
+	case "status_label":
+		return db.StatusLabel(task.Status)
+	case "trashed":
+		return strconv.FormatBool(task.Trashed)
+	case "index":
+		if task.Index == 0 {
+			return ""
+		}
+		return strconv.Itoa(task.Index)
+	case "today_index":
+		if task.TodayIndex == nil {
+			return ""
+		}
+		return strconv.Itoa(*task.TodayIndex)
+	case "tags":
+		return strings.Join(task.Tags, ",")
+	default:
+		value := taskFieldValue(task, field)
+		switch v := value.(type) {
+		case nil:
+			return ""
+		case string:
+			return v
+		case int:
+			return strconv.Itoa(v)
+		case bool:
+			return strconv.FormatBool(v)
+		case []string:
+			return strings.Join(v, ",")
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+}
+
+func writeTasks(out io.Writer, tasks []db.Task, opts TaskOutputOptions) error {
+	switch opts.Format {
+	case "json":
+		enc := json.NewEncoder(out)
+		if len(opts.Select) == 0 {
+			return enc.Encode(tasks)
+		}
+		records := make([]map[string]any, 0, len(tasks))
+		for _, task := range tasks {
+			record := make(map[string]any, len(opts.Select))
+			for _, field := range opts.Select {
+				record[field] = taskFieldValue(task, field)
+			}
+			records = append(records, record)
+		}
+		return enc.Encode(records)
+	case "jsonl":
+		enc := json.NewEncoder(out)
+		if len(opts.Select) == 0 {
+			for _, task := range tasks {
+				if err := enc.Encode(task); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		for _, task := range tasks {
+			record := make(map[string]any, len(opts.Select))
+			for _, field := range opts.Select {
+				record[field] = taskFieldValue(task, field)
+			}
+			if err := enc.Encode(record); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "csv":
+		fields := opts.Select
+		if len(fields) == 0 {
+			fields = defaultTaskTableFields
+		}
+		writer := csv.NewWriter(out)
+		if !opts.NoHeader {
+			headers := make([]string, 0, len(fields))
+			for _, field := range fields {
+				headers = append(headers, taskFieldHeaders[field])
+			}
+			if err := writer.Write(headers); err != nil {
+				return err
+			}
+		}
+		for _, task := range tasks {
+			row := make([]string, 0, len(fields))
+			for _, field := range fields {
+				row = append(row, taskFieldString(task, field))
+			}
+			if err := writer.Write(row); err != nil {
+				return err
+			}
+		}
+		writer.Flush()
+		return writer.Error()
+	case "table":
+		fields := opts.Select
+		if len(fields) == 0 {
+			fields = defaultTaskTableFields
+		}
+		return writeTaskTable(out, tasks, fields, opts.NoHeader)
+	default:
+		return fmt.Errorf("Error: invalid format %q", opts.Format)
+	}
+}
+
+func writeTaskTable(out io.Writer, tasks []db.Task, fields []string, noHeader bool) error {
+	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	if !noHeader {
+		headers := make([]string, 0, len(fields))
+		for _, field := range fields {
+			headers = append(headers, taskFieldHeaders[field])
+		}
+		fmt.Fprintln(w, strings.Join(headers, "\t"))
+	}
+	for _, task := range tasks {
+		row := make([]string, 0, len(fields))
+		for _, field := range fields {
+			row = append(row, taskFieldString(task, field))
+		}
+		fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+	return w.Flush()
+}
+
+func sortedTaskFields() []string {
+	fields := make([]string, 0, len(taskFieldHeaders))
+	for field := range taskFieldHeaders {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
+}

--- a/internal/cli/taskquery_exec.go
+++ b/internal/cli/taskquery_exec.go
@@ -1,0 +1,81 @@
+package cli
+
+import "github.com/ossianhempel/things3-cli/internal/db"
+
+func fetchTasks(store *db.Store, runner func(db.TaskFilter) ([]db.Task, error), opts TaskQueryOptions, forcePost bool, types []int) ([]db.Task, error) {
+	filter, sortSpec, err := buildTaskFilter(store, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(types) > 0 {
+		filter.Types = types
+	}
+
+	queryExpr, err := parseRichQuery(opts.Query)
+	if err != nil {
+		return nil, err
+	}
+
+	postProcess := forcePost || queryExpr != nil
+	if postProcess {
+		filter.Limit = 0
+		filter.Offset = 0
+	}
+
+	tasks, err := runner(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if queryExpr != nil {
+		tasks = filterTasksByQuery(tasks, queryExpr)
+	}
+
+	if postProcess && len(sortSpec) > 0 {
+		sortTasks(tasks, sortSpec)
+	}
+
+	if postProcess {
+		tasks = applyOffsetLimit(tasks, opts.Limit, opts.Offset)
+	}
+
+	return tasks, nil
+}
+
+func applyOffsetLimit(tasks []db.Task, limit int, offset int) []db.Task {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(tasks) {
+		return []db.Task{}
+	}
+	if offset > 0 {
+		tasks = tasks[offset:]
+	}
+	if limit > 0 && len(tasks) > limit {
+		return tasks[:limit]
+	}
+	return tasks
+}
+
+func hasExplicitSelector(cmdFlags map[string]bool, opts TaskQueryOptions) bool {
+	if opts.Search != "" || opts.Query != "" || opts.Project != "" || opts.Area != "" || opts.Tag != "" {
+		return true
+	}
+	if opts.CreatedBefore != "" || opts.CreatedAfter != "" || opts.ModifiedBefore != "" || opts.ModifiedAfter != "" {
+		return true
+	}
+	if opts.DueBefore != "" || opts.StartBefore != "" {
+		return true
+	}
+	if opts.HasURLSet {
+		return true
+	}
+	if opts.All || opts.IncludeTrashed {
+		return true
+	}
+	if cmdFlags != nil && cmdFlags["status"] {
+		return true
+	}
+	return false
+}

--- a/internal/cli/taskquery_parse.go
+++ b/internal/cli/taskquery_parse.go
@@ -1,0 +1,492 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+)
+
+type queryExpr interface {
+	Match(task db.Task) bool
+}
+
+type queryAnd struct {
+	Left  queryExpr
+	Right queryExpr
+}
+
+func (q queryAnd) Match(task db.Task) bool {
+	return q.Left.Match(task) && q.Right.Match(task)
+}
+
+type queryOr struct {
+	Left  queryExpr
+	Right queryExpr
+}
+
+func (q queryOr) Match(task db.Task) bool {
+	return q.Left.Match(task) || q.Right.Match(task)
+}
+
+type queryNot struct {
+	Inner queryExpr
+}
+
+func (q queryNot) Match(task db.Task) bool {
+	return !q.Inner.Match(task)
+}
+
+type queryPredicate struct {
+	Field   string
+	Matcher matcher
+}
+
+func (q queryPredicate) Match(task db.Task) bool {
+	field := strings.ToLower(q.Field)
+	switch field {
+	case "title":
+		return q.Matcher.Match(task.Title)
+	case "notes":
+		return q.Matcher.Match(task.Notes)
+	case "tag", "tags":
+		for _, tag := range task.Tags {
+			if q.Matcher.Match(tag) {
+				return true
+			}
+		}
+		return false
+	case "project":
+		return q.Matcher.Match(task.ProjectTitle)
+	case "area":
+		return q.Matcher.Match(task.AreaTitle)
+	case "heading":
+		return q.Matcher.Match(task.HeadingTitle)
+	case "id", "uuid":
+		return q.Matcher.Match(task.UUID)
+	case "url":
+		return matchURLPredicate(q.Matcher, task.Notes)
+	default:
+		if q.Field != "" {
+			return false
+		}
+		if q.Matcher.Match(task.Title) || q.Matcher.Match(task.Notes) {
+			return true
+		}
+		for _, tag := range task.Tags {
+			if q.Matcher.Match(tag) {
+				return true
+			}
+		}
+		if q.Matcher.Match(task.ProjectTitle) || q.Matcher.Match(task.AreaTitle) || q.Matcher.Match(task.HeadingTitle) {
+			return true
+		}
+		return false
+	}
+}
+
+type matcher struct {
+	Regex *regexp.Regexp
+	Value string
+}
+
+func (m matcher) Match(input string) bool {
+	if m.Regex != nil {
+		return m.Regex.MatchString(input)
+	}
+	return strings.Contains(strings.ToLower(input), m.Value)
+}
+
+func matchURLPredicate(m matcher, notes string) bool {
+	if m.Regex != nil {
+		return m.Regex.MatchString(notes)
+	}
+	value := strings.TrimSpace(m.Value)
+	if value == "true" {
+		return notesHasURL(notes)
+	}
+	if value == "false" {
+		return !notesHasURL(notes)
+	}
+	return strings.Contains(strings.ToLower(notes), m.Value)
+}
+
+func notesHasURL(notes string) bool {
+	notes = strings.ToLower(notes)
+	return strings.Contains(notes, "http://") || strings.Contains(notes, "https://")
+}
+
+func parseRichQuery(input string) (queryExpr, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, nil
+	}
+	lex := newQueryLexer(input)
+	tokens, err := lex.tokens()
+	if err != nil {
+		return nil, err
+	}
+	parser := queryParser{tokens: tokens}
+	expr, err := parser.parseExpression()
+	if err != nil {
+		return nil, err
+	}
+	if parser.peek().typ != tokenEOF {
+		return nil, fmt.Errorf("Error: unexpected token %q", parser.peek().value)
+	}
+	return expr, nil
+}
+
+func filterTasksByQuery(tasks []db.Task, expr queryExpr) []db.Task {
+	if expr == nil {
+		return tasks
+	}
+	filtered := make([]db.Task, 0, len(tasks))
+	for _, task := range tasks {
+		if expr.Match(task) {
+			filtered = append(filtered, task)
+		}
+	}
+	return filtered
+}
+
+type tokenType int
+
+const (
+	tokenEOF tokenType = iota
+	tokenIdent
+	tokenString
+	tokenRegex
+	tokenAnd
+	tokenOr
+	tokenNot
+	tokenLParen
+	tokenRParen
+	tokenColon
+)
+
+type token struct {
+	typ   tokenType
+	value string
+	flags string
+}
+
+type queryLexer struct {
+	input []rune
+	pos   int
+}
+
+func newQueryLexer(input string) *queryLexer {
+	return &queryLexer{input: []rune(input)}
+}
+
+func (l *queryLexer) tokens() ([]token, error) {
+	tokens := []token{}
+	for {
+		tok, err := l.nextToken()
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, tok)
+		if tok.typ == tokenEOF {
+			break
+		}
+	}
+	return tokens, nil
+}
+
+func (l *queryLexer) nextToken() (token, error) {
+	l.skipWhitespace()
+	if l.pos >= len(l.input) {
+		return token{typ: tokenEOF}, nil
+	}
+	ch := l.input[l.pos]
+	switch ch {
+	case '(':
+		l.pos++
+		return token{typ: tokenLParen, value: "("}, nil
+	case ')':
+		l.pos++
+		return token{typ: tokenRParen, value: ")"}, nil
+	case ':':
+		l.pos++
+		return token{typ: tokenColon, value: ":"}, nil
+	case '!':
+		l.pos++
+		return token{typ: tokenNot, value: "!"}, nil
+	case '"', '\'':
+		return l.scanQuoted(ch)
+	case '/':
+		return l.scanRegex()
+	case '&':
+		if l.peekNext() == '&' {
+			l.pos += 2
+			return token{typ: tokenAnd, value: "&&"}, nil
+		}
+	case '|':
+		if l.peekNext() == '|' {
+			l.pos += 2
+			return token{typ: tokenOr, value: "||"}, nil
+		}
+	}
+
+	start := l.pos
+	for l.pos < len(l.input) {
+		ch = l.input[l.pos]
+		if isDelimiter(ch) {
+			break
+		}
+		l.pos++
+	}
+	if start == l.pos {
+		return token{}, fmt.Errorf("Error: unexpected character %q", ch)
+	}
+	word := string(l.input[start:l.pos])
+	switch strings.ToLower(word) {
+	case "and":
+		return token{typ: tokenAnd, value: word}, nil
+	case "or":
+		return token{typ: tokenOr, value: word}, nil
+	case "not":
+		return token{typ: tokenNot, value: word}, nil
+	}
+	return token{typ: tokenIdent, value: word}, nil
+}
+
+func (l *queryLexer) scanQuoted(quote rune) (token, error) {
+	l.pos++
+	start := l.pos
+	escaped := false
+	var b strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		l.pos++
+		if escaped {
+			b.WriteRune(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == quote {
+			return token{typ: tokenString, value: b.String()}, nil
+		}
+		b.WriteRune(ch)
+	}
+	return token{}, fmt.Errorf("Error: unterminated string starting at %d", start)
+}
+
+func (l *queryLexer) scanRegex() (token, error) {
+	l.pos++
+	escaped := false
+	var b strings.Builder
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		l.pos++
+		if escaped {
+			b.WriteRune(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			b.WriteRune(ch)
+			continue
+		}
+		if ch == '/' {
+			flags := l.scanRegexFlags()
+			return token{typ: tokenRegex, value: b.String(), flags: flags}, nil
+		}
+		b.WriteRune(ch)
+	}
+	return token{}, fmt.Errorf("Error: unterminated regex")
+}
+
+func (l *queryLexer) scanRegexFlags() string {
+	start := l.pos
+	for l.pos < len(l.input) {
+		ch := l.input[l.pos]
+		if ch != 'i' && ch != 'm' {
+			break
+		}
+		l.pos++
+	}
+	return string(l.input[start:l.pos])
+}
+
+func (l *queryLexer) skipWhitespace() {
+	for l.pos < len(l.input) {
+		switch l.input[l.pos] {
+		case ' ', '\t', '\n', '\r':
+			l.pos++
+		default:
+			return
+		}
+	}
+}
+
+func (l *queryLexer) peekNext() rune {
+	if l.pos+1 >= len(l.input) {
+		return 0
+	}
+	return l.input[l.pos+1]
+}
+
+func isDelimiter(ch rune) bool {
+	switch ch {
+	case ' ', '\t', '\n', '\r', '(', ')', ':':
+		return true
+	default:
+		return false
+	}
+}
+
+type queryParser struct {
+	tokens []token
+	pos    int
+}
+
+func (p *queryParser) parseExpression() (queryExpr, error) {
+	return p.parseOr()
+}
+
+func (p *queryParser) parseOr() (queryExpr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		if p.match(tokenOr) {
+			right, err := p.parseAnd()
+			if err != nil {
+				return nil, err
+			}
+			left = queryOr{Left: left, Right: right}
+			continue
+		}
+		break
+	}
+	return left, nil
+}
+
+func (p *queryParser) parseAnd() (queryExpr, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		if p.match(tokenAnd) || p.canStartPrimary(p.peek()) {
+			right, err := p.parseUnary()
+			if err != nil {
+				return nil, err
+			}
+			left = queryAnd{Left: left, Right: right}
+			continue
+		}
+		break
+	}
+	return left, nil
+}
+
+func (p *queryParser) parseUnary() (queryExpr, error) {
+	if p.match(tokenNot) {
+		inner, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return queryNot{Inner: inner}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *queryParser) parsePrimary() (queryExpr, error) {
+	if p.match(tokenLParen) {
+		expr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		if !p.match(tokenRParen) {
+			return nil, fmt.Errorf("Error: expected ')'")
+		}
+		return expr, nil
+	}
+	return p.parsePredicate()
+}
+
+func (p *queryParser) parsePredicate() (queryExpr, error) {
+	field := ""
+	valueToken := p.next()
+	if valueToken.typ == tokenIdent && p.peek().typ == tokenColon {
+		field = valueToken.value
+		p.next()
+		valueToken = p.next()
+	}
+
+	switch valueToken.typ {
+	case tokenIdent, tokenString, tokenRegex:
+	default:
+		return nil, fmt.Errorf("Error: expected value after %q", field)
+	}
+
+	matcher, err := buildMatcher(valueToken)
+	if err != nil {
+		return nil, err
+	}
+	return queryPredicate{Field: field, Matcher: matcher}, nil
+}
+
+func buildMatcher(tok token) (matcher, error) {
+	switch tok.typ {
+	case tokenRegex:
+		pattern := tok.value
+		if strings.Contains(tok.flags, "i") {
+			pattern = "(?i)" + pattern
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return matcher{}, fmt.Errorf("Error: invalid regex %q", tok.value)
+		}
+		return matcher{Regex: re}, nil
+	case tokenIdent, tokenString:
+		value := strings.ToLower(tok.value)
+		return matcher{Value: value}, nil
+	default:
+		return matcher{}, fmt.Errorf("Error: invalid value %q", tok.value)
+	}
+}
+
+func (p *queryParser) peek() token {
+	if p.pos >= len(p.tokens) {
+		return token{typ: tokenEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *queryParser) next() token {
+	if p.pos >= len(p.tokens) {
+		return token{typ: tokenEOF}
+	}
+	tok := p.tokens[p.pos]
+	p.pos++
+	return tok
+}
+
+func (p *queryParser) match(typ tokenType) bool {
+	if p.peek().typ == typ {
+		p.pos++
+		return true
+	}
+	return false
+}
+
+func (p *queryParser) canStartPrimary(tok token) bool {
+	switch tok.typ {
+	case tokenIdent, tokenString, tokenRegex, tokenLParen, tokenNot:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/taskquery_sort.go
+++ b/internal/cli/taskquery_sort.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+)
+
+func sortTasks(tasks []db.Task, spec []TaskSortField) {
+	if len(spec) == 0 || len(tasks) < 2 {
+		return
+	}
+	sort.SliceStable(tasks, func(i, j int) bool {
+		left := tasks[i]
+		right := tasks[j]
+		for _, field := range spec {
+			cmp := compareTaskField(left, right, field.Field)
+			if cmp == 0 {
+				continue
+			}
+			if field.Desc {
+				return cmp > 0
+			}
+			return cmp < 0
+		}
+		return left.UUID < right.UUID
+	})
+}
+
+func compareTaskField(left db.Task, right db.Task, field string) int {
+	switch field {
+	case "created":
+		return compareString(left.Created, right.Created)
+	case "modified":
+		return compareString(left.Modified, right.Modified)
+	case "deadline":
+		return compareString(left.Deadline, right.Deadline)
+	case "start":
+		return compareString(left.StartDate, right.StartDate)
+	case "title":
+		return compareStringCI(left.Title, right.Title)
+	case "project":
+		return compareStringCI(left.ProjectTitle, right.ProjectTitle)
+	case "area":
+		return compareStringCI(left.AreaTitle, right.AreaTitle)
+	case "heading":
+		return compareStringCI(left.HeadingTitle, right.HeadingTitle)
+	case "status":
+		return compareInt(left.Status, right.Status)
+	case "uuid":
+		return compareString(left.UUID, right.UUID)
+	case "index":
+		return compareInt(left.Index, right.Index)
+	case "today_idx":
+		return compareInt(ptrToInt(left.TodayIndex), ptrToInt(right.TodayIndex))
+	default:
+		return 0
+	}
+}
+
+func compareString(left string, right string) int {
+	if left == "" && right == "" {
+		return 0
+	}
+	if left == "" {
+		return 1
+	}
+	if right == "" {
+		return -1
+	}
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}
+
+func compareStringCI(left string, right string) int {
+	return compareString(strings.ToLower(left), strings.ToLower(right))
+}
+
+func compareInt(left int, right int) int {
+	if left < right {
+		return -1
+	}
+	if left > right {
+		return 1
+	}
+	return 0
+}
+
+func ptrToInt(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}

--- a/internal/cli/tasks.go
+++ b/internal/cli/tasks.go
@@ -8,17 +8,14 @@ import (
 // NewTasksCommand builds the tasks command.
 func NewTasksCommand(app *App) *cobra.Command {
 	var dbPath string
-	var status string
-	var project string
-	var area string
-	var tag string
-	var search string
-	var includeTrashed bool
-	var all bool
-	var limit int
+	opts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
 	var asJSON bool
 	var noHeader bool
-	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:     "tasks",
@@ -31,37 +28,23 @@ func NewTasksCommand(app *App) *cobra.Command {
 			}
 			defer store.Close()
 
-			filter, err := buildTaskFilter(store, status, includeTrashed, all, project, area, tag, search, limit, recursive)
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
 			if err != nil {
 				return err
 			}
-			filter.Types = []int{db.TaskTypeTodo}
-
-			tasks, err := store.Tasks(filter)
+			tasks, err := fetchTasks(store, store.Tasks, opts, false, []int{db.TaskTypeTodo})
 			if err != nil {
 				return formatDBError(err)
 			}
-			return printTasks(app.Out, tasks, asJSON, noHeader)
+			return printTasks(app.Out, tasks, outputOpts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
-	cmd.Flags().StringVar(&status, "status", "incomplete", "Filter by status: incomplete, completed, canceled, any")
-	cmd.Flags().StringVarP(&project, "filter-project", "p", "", "Filter by project title or ID")
-	cmd.Flags().StringVar(&project, "project", "", "Alias for --filter-project")
-	cmd.Flags().StringVarP(&area, "filter-area", "a", "", "Filter by area title or ID")
-	cmd.Flags().StringVar(&area, "area", "", "Alias for --filter-area")
-	cmd.Flags().StringVarP(&tag, "filter-tag", "t", "", "Filter by tag title or ID")
-	cmd.Flags().StringVar(&tag, "filtertag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&tag, "tag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&search, "search", "", "Search title or notes (case-insensitive substring)")
-	cmd.Flags().IntVar(&limit, "limit", 200, "Limit number of results (0 = no limit)")
-	cmd.Flags().BoolVar(&includeTrashed, "include-trashed", false, "Include trashed tasks")
-	cmd.Flags().BoolVar(&all, "all", false, "Include completed, canceled, and trashed tasks")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include checklist items in JSON output")
-	cmd.Flags().BoolVarP(&asJSON, "json", "j", false, "Output JSON")
-	cmd.Flags().BoolVar(&noHeader, "no-header", false, "Suppress header row")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
 
 	return cmd
 }

--- a/internal/cli/today.go
+++ b/internal/cli/today.go
@@ -8,16 +8,14 @@ import (
 // NewTodayCommand builds the today command.
 func NewTodayCommand(app *App) *cobra.Command {
 	var dbPath string
-	var status string
-	var project string
-	var area string
-	var tag string
-	var includeTrashed bool
-	var all bool
-	var limit int
+	opts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
 	var asJSON bool
 	var noHeader bool
-	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:   "today",
@@ -29,35 +27,24 @@ func NewTodayCommand(app *App) *cobra.Command {
 			}
 			defer store.Close()
 
-			filter, err := buildTaskFilter(store, status, includeTrashed, all, project, area, tag, "", limit, recursive)
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
 			if err != nil {
 				return err
 			}
-
-			tasks, err := store.TodayTasks(filter)
+			forcePost := opts.Query != "" || opts.Sort != "" || opts.Offset > 0
+			tasks, err := fetchTasks(store, store.TodayTasks, opts, forcePost, []int{db.TaskTypeTodo})
 			if err != nil {
 				return formatDBError(err)
 			}
-			return printTasks(app.Out, tasks, asJSON, noHeader)
+			return printTasks(app.Out, tasks, outputOpts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
-	cmd.Flags().StringVar(&status, "status", "incomplete", "Filter by status: incomplete, completed, canceled, any")
-	cmd.Flags().StringVarP(&project, "filter-project", "p", "", "Filter by project title or ID")
-	cmd.Flags().StringVar(&project, "project", "", "Alias for --filter-project")
-	cmd.Flags().StringVarP(&area, "filter-area", "a", "", "Filter by area title or ID")
-	cmd.Flags().StringVar(&area, "area", "", "Alias for --filter-area")
-	cmd.Flags().StringVarP(&tag, "filter-tag", "t", "", "Filter by tag title or ID")
-	cmd.Flags().StringVar(&tag, "filtertag", "", "Alias for --filter-tag")
-	cmd.Flags().StringVar(&tag, "tag", "", "Alias for --filter-tag")
-	cmd.Flags().IntVar(&limit, "limit", 200, "Limit number of results (0 = no limit)")
-	cmd.Flags().BoolVar(&includeTrashed, "include-trashed", false, "Include trashed tasks")
-	cmd.Flags().BoolVar(&all, "all", false, "Include completed, canceled, and trashed tasks")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include checklist items in JSON output")
-	cmd.Flags().BoolVarP(&asJSON, "json", "j", false, "Output JSON")
-	cmd.Flags().BoolVar(&noHeader, "no-header", false, "Suppress header row")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
 
 	return cmd
 }

--- a/internal/cli/undo.go
+++ b/internal/cli/undo.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+	"github.com/ossianhempel/things3-cli/internal/things"
+	"github.com/spf13/cobra"
+)
+
+// NewUndoCommand builds the undo subcommand.
+func NewUndoCommand(app *App) *cobra.Command {
+	var authToken string
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "undo",
+		Short: "Undo the last bulk action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			entry, err := readLastAction()
+			if err != nil {
+				return fmt.Errorf("Error: %s", err)
+			}
+			if len(entry.Items) == 0 {
+				return fmt.Errorf("Error: no actions logged")
+			}
+
+			if app.DryRun {
+				fmt.Fprintf(app.Out, "Would undo %s for %d tasks\n", entry.Type, len(entry.Items))
+				return previewActionItems(app.Out, entry.Items)
+			}
+
+			if len(entry.Items) > 1 && !yes {
+				return fmt.Errorf("Error: %d tasks matched (rerun with --yes to apply)", len(entry.Items))
+			}
+
+			switch entry.Type {
+			case ActionUpdate:
+				token := strings.TrimSpace(authToken)
+				if token == "" {
+					token = authTokenFromEnv()
+				}
+				if token == "" {
+					_, err := things.BuildUpdateURL(things.UpdateOptions{ID: "id"}, "")
+					if err != nil {
+						return err
+					}
+				}
+				warnIncomplete := 0
+				for _, item := range entry.Items {
+					opts := things.UpdateOptions{
+						AuthToken: token,
+						ID:        item.UUID,
+						Notes:     item.Notes,
+						Tags:      strings.Join(item.Tags, ","),
+						Deadline:  item.Deadline,
+						Heading:   item.HeadingTitle,
+					}
+					when := whenFromActionItem(item)
+					if when != "" {
+						opts.When = when
+					}
+					if item.ProjectID != "" {
+						opts.ListID = item.ProjectID
+					} else if item.AreaID != "" {
+						opts.ListID = item.AreaID
+					}
+					switch item.Status {
+					case db.StatusCompleted:
+						opts.Completed = true
+					case db.StatusCanceled:
+						opts.Canceled = true
+					case db.StatusIncomplete:
+						warnIncomplete++
+					}
+					url, err := things.BuildUpdateURL(opts, item.Title)
+					if err != nil {
+						return err
+					}
+					if err := openURL(app, url); err != nil {
+						return err
+					}
+				}
+				if warnIncomplete > 0 {
+					fmt.Fprintln(app.Err, "Warning: Things URL scheme cannot un-complete tasks; some items may remain completed.")
+				}
+			case ActionTrash:
+				for _, item := range entry.Items {
+					opts := things.AddOptions{
+						Notes:    item.Notes,
+						Tags:     strings.Join(item.Tags, ","),
+						Deadline: item.Deadline,
+					}
+					when := whenFromActionItem(item)
+					if when != "" {
+						opts.When = when
+					}
+					if item.ProjectID != "" {
+						opts.ListID = item.ProjectID
+					} else if item.AreaID != "" {
+						opts.ListID = item.AreaID
+					}
+					if item.HeadingTitle != "" {
+						opts.Heading = item.HeadingTitle
+					}
+					url := things.BuildAddURL(opts, item.Title)
+					if err := openURL(app, url); err != nil {
+						return err
+					}
+				}
+				fmt.Fprintln(app.Err, "Warning: restored tasks are new items; trashed originals remain in Trash.")
+			default:
+				return fmt.Errorf("Error: unsupported action type %q", entry.Type)
+			}
+
+			if err := removeLastAction(); err != nil {
+				fmt.Fprintf(app.Err, "Warning: failed to update action log: %v\n", err)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&authToken, "auth-token", "", "Things URL scheme authorization token")
+	flags.BoolVar(&yes, "yes", false, "Confirm undo for multiple tasks")
+
+	return cmd
+}
+
+func whenFromActionItem(item ActionItem) string {
+	if item.StartDate != "" {
+		return item.StartDate
+	}
+	switch strings.ToLower(item.Start) {
+	case "inbox":
+		return "inbox"
+	case "anytime":
+		return "anytime"
+	case "someday":
+		return "someday"
+	default:
+		return ""
+	}
+}
+
+func previewActionItems(out io.Writer, items []ActionItem) error {
+	tasks := make([]db.Task, 0, len(items))
+	for _, item := range items {
+		tasks = append(tasks, db.Task{
+			UUID:   item.UUID,
+			Title:  item.Title,
+			Status: item.Status,
+		})
+	}
+	return previewTasks(out, tasks)
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
 	"github.com/ossianhempel/things3-cli/internal/things"
 	"github.com/spf13/cobra"
 )
@@ -8,6 +12,12 @@ import (
 // NewUpdateCommand builds the update subcommand.
 func NewUpdateCommand(app *App) *cobra.Command {
 	opts := things.UpdateOptions{}
+	var dbPath string
+	var yes bool
+	queryOpts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "update [OPTIONS...] [--] [-|TITLE]",
@@ -22,15 +32,110 @@ func NewUpdateCommand(app *App) *cobra.Command {
 				opts.AuthToken = authTokenFromEnv()
 			}
 
+			opts.AuthToken = strings.TrimSpace(opts.AuthToken)
+			queryOpts.HasURLSet = cmd.Flags().Changed("has-url")
+			changedStatus := cmd.Flags().Changed("status")
+			if strings.TrimSpace(opts.ID) != "" && hasExplicitSelector(map[string]bool{"status": changedStatus}, queryOpts) {
+				return fmt.Errorf("Error: use either --id or query filters")
+			}
+
+			if strings.TrimSpace(opts.ID) == "" {
+				if !hasExplicitSelector(map[string]bool{"status": changedStatus}, queryOpts) {
+					url, err := things.BuildUpdateURL(opts, rawInput)
+					if err != nil {
+						return err
+					}
+					return openURL(app, url)
+				}
+				store, _, err := db.OpenDefault(dbPath)
+				if err != nil {
+					return formatDBError(err)
+				}
+				defer store.Close()
+
+				tasks, err := fetchTasks(store, store.Tasks, queryOpts, false, []int{db.TaskTypeTodo})
+				if err != nil {
+					return formatDBError(err)
+				}
+				if len(tasks) == 0 {
+					return fmt.Errorf("Error: no tasks matched")
+				}
+				if rawInput != "" && len(tasks) > 1 {
+					return fmt.Errorf("Error: bulk update does not accept input (use --id or refine the query)")
+				}
+				if app.DryRun {
+					return previewTasks(app.Out, tasks)
+				}
+				if len(tasks) > 1 && !yes {
+					return fmt.Errorf("Error: %d tasks matched (rerun with --yes to apply)", len(tasks))
+				}
+				if opts.AuthToken == "" {
+					_, err := things.BuildUpdateURL(things.UpdateOptions{ID: "id"}, "")
+					if err != nil {
+						return err
+					}
+				}
+
+				entry := ActionEntry{
+					Type:  ActionUpdate,
+					Items: make([]ActionItem, 0, len(tasks)),
+				}
+				for _, task := range tasks {
+					entry.Items = append(entry.Items, taskToActionItem(task))
+				}
+				if err := appendAction(entry); err != nil {
+					fmt.Fprintf(app.Err, "Warning: failed to write action log: %v\n", err)
+				}
+
+				for _, task := range tasks {
+					opts.ID = task.UUID
+					url, err := things.BuildUpdateURL(opts, rawInput)
+					if err != nil {
+						return err
+					}
+					if err := openURL(app, url); err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+
 			url, err := things.BuildUpdateURL(opts, rawInput)
 			if err != nil {
 				return err
 			}
+			if app.DryRun {
+				return openURL(app, url)
+			}
+
+			if opts.AuthToken == "" {
+				_, err := things.BuildUpdateURL(things.UpdateOptions{ID: opts.ID}, "")
+				if err != nil {
+					return err
+				}
+			}
+
+			store, _, err := db.OpenDefault(dbPath)
+			if err == nil {
+				if task, err := store.TaskByID(opts.ID); err == nil {
+					entry := ActionEntry{
+						Type:  ActionUpdate,
+						Items: []ActionItem{taskToActionItem(*task)},
+					}
+					if err := appendAction(entry); err != nil {
+						fmt.Fprintf(app.Err, "Warning: failed to write action log: %v\n", err)
+					}
+				}
+				store.Close()
+			}
+
 			return openURL(app, url)
 		},
 	}
 
 	flags := cmd.Flags()
+	flags.StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
+	flags.StringVar(&dbPath, "database", "", "Alias for --db")
 	flags.StringVar(&opts.AuthToken, "auth-token", "", "Things URL scheme authorization token")
 	flags.StringVar(&opts.ID, "id", "", "ID of the todo to update")
 	flags.StringVar(&opts.Notes, "notes", "", "Replace notes")
@@ -54,6 +159,8 @@ func NewUpdateCommand(app *App) *cobra.Command {
 	flags.StringArrayVar(&opts.ChecklistItems, "checklist-item", nil, "Checklist item (repeatable)")
 	flags.StringArrayVar(&opts.PrependChecklistItems, "prepend-checklist-item", nil, "Prepend checklist item (repeatable)")
 	flags.StringArrayVar(&opts.AppendChecklistItems, "append-checklist-item", nil, "Append checklist item (repeatable)")
+	flags.BoolVar(&yes, "yes", false, "Confirm bulk update")
+	addTaskQueryFlags(cmd, &queryOpts, true, true)
 
 	return cmd
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -100,16 +100,25 @@ type ProjectFilter struct {
 }
 
 type TaskFilter struct {
-	Status           *int
-	IncludeTrashed   bool
+	Status                *int
+	IncludeTrashed        bool
 	ExcludeTrashedContext bool
-	ProjectID        string
-	AreaID           string
-	TagID            string
-	Search           string
-	Limit            int
-	IncludeChecklist bool
-	Types            []int
+	ProjectID             string
+	AreaID                string
+	TagID                 string
+	Search                string
+	Limit                 int
+	Offset                int
+	IncludeChecklist      bool
+	Types                 []int
+	CreatedBefore         *float64
+	CreatedAfter          *float64
+	ModifiedBefore        *float64
+	ModifiedAfter         *float64
+	DueBefore             *int
+	StartBefore           *int
+	HasURL                *bool
+	Order                 string
 }
 
 func StatusLabel(status int) string {

--- a/internal/db/tree.go
+++ b/internal/db/tree.go
@@ -123,10 +123,10 @@ func (s *Store) projectChildren(projectID string, filter TaskFilter) ([]TreeItem
 	}
 
 	for _, heading := range headings {
-			taskFilter := filter
-			taskFilter.ProjectID = projectID
-			taskFilter.Types = []int{TaskTypeTodo}
-			tasks, err := s.queryTasks("t.project = ? AND t.heading = ?", []any{projectID, heading.UUID}, taskFilter, "")
+		taskFilter := filter
+		taskFilter.ProjectID = projectID
+		taskFilter.Types = []int{TaskTypeTodo}
+		tasks, err := s.queryTasks("t.project = ? AND t.heading = ?", []any{projectID, heading.UUID}, taskFilter, "")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/things/applescript.go
+++ b/internal/things/applescript.go
@@ -1,0 +1,8 @@
+package things
+
+import "strings"
+
+func escapeAppleScriptString(input string) string {
+	replaced := strings.ReplaceAll(input, "\\", "\\\\")
+	return strings.ReplaceAll(replaced, "\"", "\\\"")
+}

--- a/internal/things/area.go
+++ b/internal/things/area.go
@@ -95,8 +95,3 @@ func areaTarget(id string, title string) string {
 	}
 	return fmt.Sprintf("first area whose id is \"%s\"", escapeAppleScriptString(id))
 }
-
-func escapeAppleScriptString(input string) string {
-	replaced := strings.ReplaceAll(input, "\\", "\\\\")
-	return strings.ReplaceAll(replaced, "\"", "\\\"")
-}

--- a/internal/things/trash.go
+++ b/internal/things/trash.go
@@ -1,0 +1,36 @@
+package things
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildTrashScript builds an AppleScript snippet to move todos to Trash.
+func BuildTrashScript(ids []string) (string, error) {
+	if len(ids) == 0 {
+		return "", fmt.Errorf("Error: Must specify --id=ID or query")
+	}
+	quoted := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		quoted = append(quoted, "\""+escapeAppleScriptString(id)+"\"")
+	}
+	if len(quoted) == 0 {
+		return "", fmt.Errorf("Error: Must specify --id=ID or query")
+	}
+
+	var b strings.Builder
+	b.WriteString("tell application \"Things3\"\n")
+	b.WriteString("  repeat with todoID in {")
+	b.WriteString(strings.Join(quoted, ", "))
+	b.WriteString("}\n")
+	b.WriteString("    try\n")
+	b.WriteString("      delete to do id todoID\n")
+	b.WriteString("    end try\n")
+	b.WriteString("  end repeat\n")
+	b.WriteString("end tell")
+	return b.String(), nil
+}


### PR DESCRIPTION
## Summary
- Add rich query syntax (`--query`) with boolean ops, parentheses, and regex across task fields.
- Add timestamp filters (`--created-*`, `--modified-*`, `--due-before`, `--start-before`) and `--has-url` filter.
- Add output controls: `--format table|json|jsonl|csv`, `--select`, `--sort`, and `--offset`.
- Enable bulk update/delete by query with `--dry-run` previews and `--yes` confirmation.
- Add action log + `things undo` for last bulk update/trash.
- Add AppleScript trash support.

## Details (what changed)
- **Query parsing & execution:** `internal/cli/taskquery_parse.go`, `internal/cli/taskquery_exec.go`, `internal/cli/taskquery_sort.go`, `internal/cli/taskfilter.go`.
- **DB filtering & ordering:** `internal/db/models.go`, `internal/db/queries.go` (timestamp bounds, has-url, order/offset, TaskByID).
- **Shared flags/output:** `internal/cli/taskflags.go`, `internal/cli/taskoutput.go`, `internal/cli/dboutput.go`.
- **Bulk actions:** `internal/cli/update.go`, `internal/cli/delete.go`, `internal/cli/preview.go`.
- **Undo log:** `internal/cli/actionlog.go`, `internal/cli/undo.go`.
- **AppleScript trash:** `internal/things/trash.go`, `internal/things/applescript.go`.
- **Docs:** `internal/cli/helptext.go`, `README.md`.

## Testing
- `make test`

## Notes
- Delete uses AppleScript and may trigger macOS automation prompts.
- Undoing trash recreates tasks as new items; un-complete is limited by Things URL scheme.
