### PR TITLE
fix: security hardening and low-severity findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Build static site
         run: |
@@ -34,7 +34,7 @@ jobs:
           cp -R docs/site/* _site/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: _site
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,14 @@ jobs:
         run: go test ./...
 
       - name: Build release artifacts
-        run: ./scripts/build-release.sh "${{ steps.version.outputs.tag }}"
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: ./scripts/build-release.sh "$RELEASE_TAG"
 
       - name: Generate release notes
-        run: ./scripts/release-notes.sh "${{ steps.version.outputs.tag }}" > dist/release-notes.md
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: ./scripts/release-notes.sh "$RELEASE_TAG" > dist/release-notes.md
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,15 @@ jobs:
 
       - name: Set version
         id: version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="v${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="v${INPUT_VERSION}"
           else
-            VERSION="${{ github.ref_name }}"
+            VERSION="${REF_NAME}"
           fi
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,18 @@ on:
         description: 'Version to release (e.g., 0.1.0)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
@@ -44,7 +47,7 @@ jobs:
         run: ./scripts/release-notes.sh "${{ steps.version.outputs.tag }}" > dist/release-notes.md
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: things3-cli ${{ steps.version.outputs.tag }}

--- a/internal/cli/actionlog.go
+++ b/internal/cli/actionlog.go
@@ -57,7 +57,7 @@ func appendAction(entry ActionEntry) error {
 		return err
 	}
 	entry.Timestamp = time.Now().Format(time.RFC3339)
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func removeLastAction() error {
 		}
 	}
 	content := strings.Join(lines, "\n")
-	return os.WriteFile(path, []byte(content), 0o644)
+	return os.WriteFile(path, []byte(content), 0o600)
 }
 
 func taskToActionItem(task db.Task) ActionItem {

--- a/internal/things/add.go
+++ b/internal/things/add.go
@@ -72,7 +72,7 @@ func BuildAddURL(opts AddOptions, rawInput string) string {
 	}
 
 	if opts.UseClipboard != "" {
-		params = append(params, "use-clipboard="+opts.UseClipboard)
+		params = append(params, "use-clipboard="+URLEncode(opts.UseClipboard))
 	}
 
 	if opts.Heading != "" {

--- a/internal/things/area.go
+++ b/internal/things/area.go
@@ -128,5 +128,8 @@ func areaTarget(id string, title string) string {
 
 func escapeAppleScriptString(input string) string {
 	replaced := strings.ReplaceAll(input, "\\", "\\\\")
-	return strings.ReplaceAll(replaced, "\"", "\\\"")
+	replaced = strings.ReplaceAll(replaced, "\"", "\\\"")
+	replaced = strings.ReplaceAll(replaced, "\n", "\\n")
+	replaced = strings.ReplaceAll(replaced, "\r", "\\r")
+	return replaced
 }


### PR DESCRIPTION
## Summary

- Restrict action log file permissions from 0644 to 0600
- Move workflow_dispatch inputs and step outputs to env vars to prevent shell injection
- Escape LIKE metacharacters (%, _) in search queries
- Redact auth tokens in dry-run and debug output
- URL-encode use-clipboard parameter in add URLs
- Escape newlines in AppleScript string interpolation
- Pin GitHub Actions to SHA hashes and scope workflow permissions

## Test plan

- [x] `go test ./...` — all tests pass
- [x] Manual CLI testing across all commands
- [x] Security review confirmed all fixes applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)