### PR TITLE
Little race condition fix + gitignore addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
+# Build output
+bin/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/internal/cli/actionlog.go
+++ b/internal/cli/actionlog.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,10 +107,21 @@ func removeLastAction() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	return removeLastActionFromPath(path)
+}
+
+func removeLastActionFromPath(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
 	lines := strings.Split(string(data), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		if strings.TrimSpace(lines[i]) != "" {
@@ -118,7 +130,14 @@ func removeLastAction() error {
 		}
 	}
 	content := strings.Join(lines, "\n")
-	return os.WriteFile(path, []byte(content), 0o644)
+
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if _, err := file.WriteString(content); err != nil {
+		return err
+	}
+	return file.Truncate(int64(len(content)))
 }
 
 func taskToActionItem(task db.Task) ActionItem {

--- a/internal/cli/actionlog_test.go
+++ b/internal/cli/actionlog_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeActionLog(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "actions.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write action log: %v", err)
+	}
+	return path
+}
+
+func readActionLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read action log: %v", err)
+	}
+	return string(data)
+}
+
+func TestRemoveLastActionFromPath(t *testing.T) {
+	t.Run("removes last line", func(t *testing.T) {
+		path := writeActionLog(t, `{"type":"update","items":[]}`+"\n"+`{"type":"trash","items":[]}`+"\n")
+		if err := removeLastActionFromPath(path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := readActionLog(t, path)
+		want := `{"type":"update","items":[]}` + "\n"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("removes only entry", func(t *testing.T) {
+		path := writeActionLog(t, `{"type":"update","items":[]}`+"\n")
+		if err := removeLastActionFromPath(path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := readActionLog(t, path)
+		if got != "" {
+			t.Errorf("expected empty file, got %q", got)
+		}
+	})
+
+	t.Run("handles trailing newlines", func(t *testing.T) {
+		path := writeActionLog(t, `{"type":"update","items":[]}`+"\n"+`{"type":"trash","items":[]}`+"\n\n\n")
+		if err := removeLastActionFromPath(path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := readActionLog(t, path)
+		want := `{"type":"update","items":[]}` + "\n\n\n"
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		err := removeLastActionFromPath(filepath.Join(t.TempDir(), "nonexistent.jsonl"))
+		if err == nil {
+			t.Error("expected error for missing file, got nil")
+		}
+	})
+}


### PR DESCRIPTION
👋 hey! Thanks for building this tool, it's great!

While reviewing the code, I found a small race condition + missing `.gitignore` entry. Honestly, neither is that big of a deal. But thought I'd raise them, propose fixes, and let you decide what to do. I will not be offended if you just close this PR 🙂 

## Changes
1. `actionlog.go` - Race condition fix. Refactor `removeLastAction()` to use a single open file handle instead of separate read/write calls. This makes the file modification atomic. 
2. `.gitignore` - Adding `bin/` to ignore build outputs generated by the `Makefile`