### PR TITLE
Add update-project, list-project-tasks, and rename-project commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+bin/

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -2390,3 +2390,81 @@ EXAMPLES
 SEE ALSO
   Authorization: https://culturedcode.com/things/support/articles/2803573/#overview-authorization
 `
+
+const listProjectTasksHelp = `Usage: things list-project-tasks --id <UUID> [OPTIONS...]
+
+NAME
+  things list-project-tasks - list todos belonging to a project
+
+SYNOPSIS
+  things list-project-tasks --id <UUID> [OPTIONS...]
+
+DESCRIPTION
+  Lists todos that belong to the project identified by {{BT}}--id={{BT}}.
+  Reads from the local Things database (read-only).
+
+  By default only incomplete, non-trashed tasks are shown.
+
+OPTIONS
+  --id=UUID
+    UUID of the project whose tasks to list. Required.
+
+  --db=PATH
+    Path to the Things database. Overrides the THINGSDB environment variable.
+
+  --status=STATUS
+    Filter by status: incomplete, completed, canceled, any. Default: incomplete.
+
+  --limit=N
+    Limit number of results (0 = no limit). Default: 200.
+
+  --json
+    Output JSON.
+
+  --format=FORMAT
+    Output format: table, json, jsonl, csv.
+
+  --no-header
+    Suppress the header row.
+
+EXAMPLES
+  things list-project-tasks --id=8TN1bbz946oBsRBGiQ2XBN
+
+  things list-project-tasks --id=8TN1bbz946oBsRBGiQ2XBN --status=any --json
+`
+
+const renameProjectHelp = `Usage: things rename-project --id <UUID> --title <TITLE>
+
+NAME
+  things rename-project - rename an existing project
+
+SYNOPSIS
+  things rename-project --id <UUID> --title <TITLE>
+
+DESCRIPTION
+  Renames an existing project identified by {{BT}}--id={{BT}} to the new title
+  given by {{BT}}--title={{BT}}.
+
+AUTHORIZATION
+  Update commands require a Things URL scheme token. Run {{BT}}things auth{{BT}}
+  for setup, set {{BT}}THINGS_AUTH_TOKEN{{BT}}, or pass {{BT}}--auth-token{{BT}}.
+
+  Token setup:
+    1. Open Things 3.
+    2. Settings -> General -> Things URLs.
+    3. Copy the token (or enable "Allow 'things' CLI to access Things").
+
+OPTIONS
+  --auth-token=TOKEN
+    The Things URL scheme authorization token. Required. See above for more
+    information on authorization. If not provided, uses THINGS_AUTH_TOKEN.
+
+  --id=UUID
+    The ID of the project to rename. Required.
+
+  --title=TITLE
+    The new title for the project. Required.
+
+EXAMPLES
+  things rename-project --id=8TN1bbz946oBsRBGiQ2XBN --title="My New Name"
+`

--- a/internal/cli/list_project_tasks.go
+++ b/internal/cli/list_project_tasks.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/ossianhempel/things3-cli/internal/db"
+	"github.com/spf13/cobra"
+)
+
+// NewListProjectTasksCommand builds the list-project-tasks subcommand.
+func NewListProjectTasksCommand(app *App) *cobra.Command {
+	var dbPath string
+	var id string
+	opts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
+	var asJSON bool
+	var noHeader bool
+
+	cmd := &cobra.Command{
+		Use:   "list-project-tasks --id <UUID>",
+		Short: "List todos belonging to a project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if id == "" {
+				return fmt.Errorf("Error: --id is required")
+			}
+
+			store, _, err := db.OpenDefault(dbPath)
+			if err != nil {
+				return formatDBError(err)
+			}
+			defer store.Close()
+
+			opts.Project = id
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
+			if err != nil {
+				return err
+			}
+			tasks, err := fetchTasks(store, store.Tasks, opts, false, []int{db.TaskTypeTodo})
+			if err != nil {
+				return formatDBError(err)
+			}
+			return printTasks(app.Out, tasks, outputOpts)
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "UUID of the project whose tasks to list (required)")
+	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
+	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
+
+	return cmd
+}

--- a/internal/cli/rename_project.go
+++ b/internal/cli/rename_project.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"github.com/ossianhempel/things3-cli/internal/things"
+	"github.com/spf13/cobra"
+)
+
+// NewRenameProjectCommand builds the rename-project subcommand.
+func NewRenameProjectCommand(app *App) *cobra.Command {
+	opts := things.RenameProjectOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "rename-project --id <UUID> --title <TITLE>",
+		Short: "Rename an existing project",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token, err := resolveAuthToken(app, opts.AuthToken)
+			if err != nil {
+				return err
+			}
+			opts.AuthToken = token
+
+			url, err := things.BuildRenameProjectURL(opts)
+			if err != nil {
+				return err
+			}
+			return openURL(app, url)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.AuthToken, "auth-token", "", "Things URL scheme authorization token")
+	flags.StringVar(&opts.ID, "id", "", "ID of the project to rename")
+	flags.StringVar(&opts.Title, "title", "", "New title for the project")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -61,6 +61,8 @@ func NewRoot(app *App) *cobra.Command {
 	cmd.AddCommand(NewDeleteAreaCommand(app))
 	cmd.AddCommand(NewDeleteProjectCommand(app))
 	cmd.AddCommand(NewUpdateProjectCommand(app))
+	cmd.AddCommand(NewListProjectTasksCommand(app))
+	cmd.AddCommand(NewRenameProjectCommand(app))
 	cmd.AddCommand(NewUndoCommand(app))
 	cmd.AddCommand(NewShowCommand(app))
 	cmd.AddCommand(NewSearchCommand(app))
@@ -138,6 +140,10 @@ func NewRoot(app *App) *cobra.Command {
 				printHelp(app.Out, formatHelpText(updateProjectHelp, isTTY(app.Out)))
 			case "delete-project":
 				printHelp(app.Out, formatHelpText(deleteProjectHelp, isTTY(app.Out)))
+			case "list-project-tasks":
+				printHelp(app.Out, formatHelpText(listProjectTasksHelp, isTTY(app.Out)))
+			case "rename-project":
+				printHelp(app.Out, formatHelpText(renameProjectHelp, isTTY(app.Out)))
 			case "help":
 				printHelp(app.Out, formatHelpText(rootHelp, isTTY(app.Out)))
 			default:
@@ -218,6 +224,10 @@ func NewRoot(app *App) *cobra.Command {
 			printHelp(app.Out, formatHelpText(updateProjectHelp, isTTY(app.Out)))
 		case "delete-project":
 			printHelp(app.Out, formatHelpText(deleteProjectHelp, isTTY(app.Out)))
+		case "list-project-tasks":
+			printHelp(app.Out, formatHelpText(listProjectTasksHelp, isTTY(app.Out)))
+		case "rename-project":
+			printHelp(app.Out, formatHelpText(renameProjectHelp, isTTY(app.Out)))
 		default:
 			printHelp(app.Out, formatHelpText(rootHelp, isTTY(app.Out)))
 		}

--- a/internal/things/rename_project.go
+++ b/internal/things/rename_project.go
@@ -1,0 +1,31 @@
+package things
+
+import "strings"
+
+// RenameProjectOptions defines options for rename-project.
+type RenameProjectOptions struct {
+	AuthToken string
+	ID        string
+	Title     string
+}
+
+// BuildRenameProjectURL builds a Things URL for the rename-project command.
+func BuildRenameProjectURL(opts RenameProjectOptions) (string, error) {
+	if opts.AuthToken == "" {
+		return "", ErrMissingAuthToken
+	}
+	if opts.ID == "" {
+		return "", errMissingID
+	}
+	if opts.Title == "" {
+		return "", errMissingTitle
+	}
+
+	params := []string{
+		"auth-token=" + URLEncode(opts.AuthToken),
+		"id=" + URLEncode(opts.ID),
+		"title=" + URLEncode(opts.Title),
+	}
+
+	return "things:///update-project?" + strings.Join(params, "&") + "&", nil
+}


### PR DESCRIPTION
Hi all, the motivation for this pull request was because I needed a way to interact with the project metadata and assign tasks to projects!
This PR adds three new commands for managing Things 3 projects via the CLI:

## New Commands

### `update-project`
Update a project's notes and tags via the Things URL scheme.
```
things update-project --id <UUID> --notes "..." --tags "T,S"
```

### `list-project-tasks`
List all tasks belonging to a project by UUID, reading directly from the SQLite database.
```
things list-project-tasks --id <UUID>
```

### `rename-project`
Rename a project via the Things URL scheme.
```
things rename-project --id <UUID> --title "New Name"
```

## Motivation
The existing `update` command only works on to-dos — passing a project UUID throws `Cannot update to-do with ID ... because it does not exist`. There was no way to manage project-level metadata (notes, tags, title) from the CLI, which limits automation workflows.

Related to issue #8.