### PR TITLE
Add checklist support to show

### DIFF
--- a/doc/man/things.1.md
+++ b/doc/man/things.1.md
@@ -756,6 +756,9 @@ If `-` is given as a query, it is read from STDIN.
   The ID of an area, project, tag, or todo to show. Takes precedence over
   QUERY. Required if QUERY is not supplied.
 
+*--recursive*
+  Include checklist items when showing to-dos.
+
 *--json*
   Output JSON.
 

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -29,3 +29,19 @@ func TestShowAcceptsQueryFromStdin(t *testing.T) {
 	requireSuccess(t, code)
 	assertContains(t, out, "Project One")
 }
+
+func TestShowRecursiveIncludesChecklist(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "show", "--db", dbPath, "--id=T1", "--recursive")
+	requireSuccess(t, code)
+	assertContains(t, out, "CHECKLIST")
+	assertContains(t, out, "Check Item")
+}
+
+func TestShowRecursiveIncludesChecklistJSON(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "show", "--db", dbPath, "--id=T1", "--recursive", "--json")
+	requireSuccess(t, code)
+	assertContains(t, out, `"checklist":[`)
+	assertContains(t, out, `"title":"Check Item"`)
+}

--- a/internal/cli/dboutput.go
+++ b/internal/cli/dboutput.go
@@ -114,7 +114,29 @@ func printItem(out io.Writer, item *db.Item, asJSON bool, noHeader bool) error {
 	}
 	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 		item.Type, item.UUID, item.Title, status, trashed, item.ProjectTitle, item.AreaTitle, item.HeadingTitle, visible, item.Shortcut, item.ParentID)
-	return w.Flush()
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if len(item.Checklist) == 0 {
+		return nil
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "CHECKLIST")
+	for _, checklistItem := range item.Checklist {
+		fmt.Fprintf(out, "[%s] %s\n", checklistStatusMarker(checklistItem.Status), checklistItem.Title)
+	}
+	return nil
+}
+
+func checklistStatusMarker(status int) string {
+	switch status {
+	case db.StatusCompleted:
+		return "x"
+	case db.StatusCanceled:
+		return "-"
+	default:
+		return " "
+	}
 }
 
 func printTree(out io.Writer, items []db.TreeItem, asJSON bool) error {

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -1775,6 +1775,9 @@ OPTIONS
     The ID of an area, project, tag, or todo to show. Takes precedence over
     QUERY. Required if QUERY is not supplied.
 
+  --recursive
+    Include checklist items when showing to-dos.
+
   --json
     Output JSON.
 

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -16,6 +16,7 @@ func NewShowCommand(app *App) *cobra.Command {
 	var id string
 	var asJSON bool
 	var noHeader bool
+	var recursive bool
 
 	cmd := &cobra.Command{
 		Use:   "show [OPTIONS...] [--] [-|QUERY]",
@@ -41,7 +42,7 @@ func NewShowCommand(app *App) *cobra.Command {
 			defer store.Close()
 
 			if id != "" {
-				item, err := store.ItemByID(id)
+				item, err := store.ItemByID(id, recursive)
 				if err != nil {
 					if errors.Is(err, sql.ErrNoRows) {
 						return fmt.Errorf("Error: item not found")
@@ -51,7 +52,7 @@ func NewShowCommand(app *App) *cobra.Command {
 				return printItem(app.Out, item, asJSON, noHeader)
 			}
 
-			items, err := store.ItemsByTitle(query)
+			items, err := store.ItemsByTitle(query, recursive)
 			if err != nil {
 				return formatDBError(err)
 			}
@@ -69,6 +70,7 @@ func NewShowCommand(app *App) *cobra.Command {
 	flags.StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
 	flags.StringVar(&dbPath, "database", "", "Alias for --db")
 	flags.StringVar(&id, "id", "", "ID of area/project/tag/todo")
+	flags.BoolVarP(&recursive, "recursive", "r", false, "Include checklist items when showing to-dos")
 	flags.BoolVarP(&asJSON, "json", "j", false, "Output JSON")
 	flags.BoolVar(&noHeader, "no-header", false, "Suppress header row")
 

--- a/internal/cli/show_test.go
+++ b/internal/cli/show_test.go
@@ -68,3 +68,49 @@ func TestShowCommandRequiresTarget(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestShowCommandRecursiveIncludesChecklist(t *testing.T) {
+	dbPath := writeTestDB(t)
+	app := &App{
+		In:  strings.NewReader(""),
+		Out: &bytes.Buffer{},
+		Err: &bytes.Buffer{},
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"show", "--db", dbPath, "--id", "T1", "--recursive"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	output := app.Out.(*bytes.Buffer).String()
+	if !strings.Contains(output, "CHECKLIST") || !strings.Contains(output, "Check Item") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestShowCommandRecursiveIncludesChecklistJSON(t *testing.T) {
+	dbPath := writeTestDB(t)
+	app := &App{
+		In:  strings.NewReader(""),
+		Out: &bytes.Buffer{},
+		Err: &bytes.Buffer{},
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"show", "--db", dbPath, "--id", "T1", "--recursive", "--json"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	output := app.Out.(*bytes.Buffer).String()
+	if !strings.Contains(output, `"checklist":[`) || !strings.Contains(output, `"title":"Check Item"`) {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}

--- a/internal/db/items_test.go
+++ b/internal/db/items_test.go
@@ -18,7 +18,7 @@ func TestItemByID(t *testing.T) {
 
 	store := &Store{conn: conn, path: ":memory:"}
 
-	item, err := store.ItemByID("P1")
+	item, err := store.ItemByID("P1", false)
 	if err != nil {
 		t.Fatalf("item by id: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestItemByID(t *testing.T) {
 		t.Fatalf("unexpected project item: %#v", item)
 	}
 
-	item, err = store.ItemByID("TAG1")
+	item, err = store.ItemByID("TAG1", false)
 	if err != nil {
 		t.Fatalf("item by id tag: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestItemsByTitle(t *testing.T) {
 
 	store := &Store{conn: conn, path: ":memory:"}
 
-	items, err := store.ItemsByTitle("Home")
+	items, err := store.ItemsByTitle("Home", false)
 	if err != nil {
 		t.Fatalf("items by title: %v", err)
 	}
@@ -56,11 +56,33 @@ func TestItemsByTitle(t *testing.T) {
 		t.Fatalf("unexpected area items: %#v", items)
 	}
 
-	items, err = store.ItemsByTitle("Task One")
+	items, err = store.ItemsByTitle("Task One", false)
 	if err != nil {
 		t.Fatalf("items by title task: %v", err)
 	}
 	if len(items) != 1 || items[0].Type != "to-do" {
 		t.Fatalf("unexpected task items: %#v", items)
+	}
+}
+
+func TestItemByIDWithChecklist(t *testing.T) {
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer conn.Close()
+
+	if err := seedTestDB(conn); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	store := &Store{conn: conn, path: ":memory:"}
+
+	item, err := store.ItemByID("T1", true)
+	if err != nil {
+		t.Fatalf("item by id with checklist: %v", err)
+	}
+	if len(item.Checklist) != 1 || item.Checklist[0].Title != "Check Item" {
+		t.Fatalf("unexpected checklist: %#v", item.Checklist)
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -77,6 +77,7 @@ type Item struct {
 	Title        string `json:"title"`
 	Status       *int   `json:"status,omitempty"`
 	Trashed      *bool  `json:"trashed,omitempty"`
+	Checklist    []ChecklistItem `json:"checklist,omitempty"`
 	ProjectTitle string `json:"project_title,omitempty"`
 	AreaTitle    string `json:"area_title,omitempty"`
 	HeadingTitle string `json:"heading_title,omitempty"`

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -310,7 +310,7 @@ func (s *Store) TasksCompletedBetween(start, end time.Time, filter TaskFilter) (
 }
 
 // ItemByID returns a single item (task/project/heading, area, or tag) by UUID.
-func (s *Store) ItemByID(id string) (*Item, error) {
+func (s *Store) ItemByID(id string, includeChecklist bool) (*Item, error) {
 	if s == nil || s.conn == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -344,6 +344,13 @@ func (s *Store) ItemByID(id string) (*Item, error) {
 		}
 		if headingTitle.Valid {
 			item.HeadingTitle = headingTitle.String
+		}
+		if includeChecklist && item.Type == "to-do" {
+			checklist, err := loadChecklistItems(s.conn, []string{item.UUID})
+			if err != nil {
+				return nil, err
+			}
+			item.Checklist = checklist[item.UUID]
 		}
 		return &item, nil
 	} else if err != sql.ErrNoRows {
@@ -383,7 +390,7 @@ func (s *Store) ItemByID(id string) (*Item, error) {
 }
 
 // ItemsByTitle returns matching items by exact title (case-insensitive).
-func (s *Store) ItemsByTitle(title string) ([]Item, error) {
+func (s *Store) ItemsByTitle(title string, includeChecklist bool) ([]Item, error) {
 	if s == nil || s.conn == nil {
 		return nil, fmt.Errorf("database not initialized")
 	}
@@ -433,6 +440,26 @@ func (s *Store) ItemsByTitle(title string) ([]Item, error) {
 		return nil, err
 	}
 	rows.Close()
+
+	if includeChecklist {
+		taskIDs := make([]string, 0, len(items))
+		for _, item := range items {
+			if item.Type == "to-do" {
+				taskIDs = append(taskIDs, item.UUID)
+			}
+		}
+		if len(taskIDs) > 0 {
+			checklist, err := loadChecklistItems(s.conn, taskIDs)
+			if err != nil {
+				return nil, err
+			}
+			for i := range items {
+				if items[i].Type == "to-do" {
+					items[i].Checklist = checklist[items[i].UUID]
+				}
+			}
+		}
+	}
 
 	rows, err = s.conn.Query("SELECT uuid, title, visible FROM TMArea WHERE lower(title) = lower(?)", title)
 	if err != nil {

--- a/share/man/man1/things.1
+++ b/share/man/man1/things.1
@@ -958,20 +958,16 @@ The ID of an area, project, tag, or todo to show\. Takes precedence over
 QUERY\. Required if QUERY is not supplied\.
 .LP
 .TP
+\fB--recursive\fR
+Include checklist items when showing to-dos\.
+.LP
+.TP
 \fB--json\fR
 Output JSON\.
 .LP
 .TP
 \fB--no-header\fR
 Suppress the header row\.
-.LP
-.TP
-\fB--recursive\fR
-Include nested headings/todos\.
-.LP
-.TP
-\fB--only-projects\fR
-Only include projects\. Implies \fB--recursive\fR\.
 .LP
 .PP
 \fBNOTES\fP


### PR DESCRIPTION
## Summary
- add  to include checklist items for to-dos
- include checklist data in JSON output and print a checklist section in table output
- add unit and integration coverage for recursive show output

## Testing
- not run in this environment because the Go toolchain is not installed