### PR TITLE
fix: expose start_bucket for today output

### DIFF
--- a/integration/db_helpers_test.go
+++ b/integration/db_helpers_test.go
@@ -32,6 +32,7 @@ func writeTestDB(t *testing.T) string {
 			heading TEXT,
 			start INTEGER,
 			startDate INTEGER,
+			startBucket INTEGER,
 			deadline INTEGER,
 			deadlineSuppressionDate INTEGER,
 			creationDate REAL,

--- a/internal/cli/dbtest_helpers_test.go
+++ b/internal/cli/dbtest_helpers_test.go
@@ -30,6 +30,7 @@ func writeTestDB(t *testing.T) string {
 			heading TEXT,
 			start INTEGER,
 			startDate INTEGER,
+			startBucket INTEGER,
 			deadline INTEGER,
 			deadlineSuppressionDate INTEGER,
 			creationDate REAL,

--- a/internal/cli/taskoutput.go
+++ b/internal/cli/taskoutput.go
@@ -90,6 +90,9 @@ var taskFieldAliases = map[string]string{
 	"area_title":    "area",
 	"heading_title": "heading",
 	"status_label":  "status_label",
+	"startbucket":   "start_bucket",
+	"start-bucket":  "start_bucket",
+	"start_bucket":  "start_bucket",
 	"todayindex":    "today_index",
 	"today-index":   "today_index",
 	"today_index":   "today_index",
@@ -111,6 +114,7 @@ var taskFieldHeaders = map[string]string{
 	"notes":        "NOTES",
 	"start":        "START",
 	"start_date":   "START_DATE",
+	"start_bucket": "START_BUCKET",
 	"repeating":    "REPEATING",
 	"deadline":     "DEADLINE",
 	"stop_date":    "STOP_DATE",
@@ -162,6 +166,11 @@ func taskFieldValue(task db.Task, field string) any {
 		return task.Start
 	case "start_date":
 		return task.StartDate
+	case "start_bucket":
+		if task.StartBucket == nil {
+			return nil
+		}
+		return *task.StartBucket
 	case "repeating":
 		return task.Repeating
 	case "deadline":
@@ -206,6 +215,11 @@ func taskFieldString(task db.Task, field string) string {
 			return ""
 		}
 		return strconv.Itoa(*task.TodayIndex)
+	case "start_bucket":
+		if task.StartBucket == nil {
+			return ""
+		}
+		return strconv.Itoa(*task.StartBucket)
 	case "tags":
 		return strings.Join(task.Tags, ",")
 	default:

--- a/internal/cli/taskoutput_test.go
+++ b/internal/cli/taskoutput_test.go
@@ -36,10 +36,11 @@ func TestResolveTaskOutputOptionsInvalidFormat(t *testing.T) {
 }
 
 func TestWriteTasksCSVSelect(t *testing.T) {
-	task := db.Task{UUID: "ABC", Title: "Task", Status: db.StatusCompleted}
+	startBucket := 1
+	task := db.Task{UUID: "ABC", Title: "Task", Status: db.StatusCompleted, StartBucket: &startBucket}
 	opts := TaskOutputOptions{
 		Format: "csv",
-		Select: []string{"uuid", "title", "status"},
+		Select: []string{"uuid", "title", "status", "start_bucket"},
 	}
 	var buf bytes.Buffer
 	if err := writeTasks(&buf, []db.Task{task}, opts); err != nil {
@@ -50,10 +51,10 @@ func TestWriteTasksCSVSelect(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	if lines[0] != "UUID,TITLE,STATUS" {
+	if lines[0] != "UUID,TITLE,STATUS,START_BUCKET" {
 		t.Fatalf("unexpected header: %q", lines[0])
 	}
-	if !strings.Contains(lines[1], "ABC,Task,completed") {
+	if !strings.Contains(lines[1], "ABC,Task,completed,1") {
 		t.Fatalf("unexpected row: %q", lines[1])
 	}
 }

--- a/internal/db/lists_test.go
+++ b/internal/db/lists_test.go
@@ -67,6 +67,7 @@ func seedListDB(conn *sql.DB) error {
 			heading TEXT,
 			start INTEGER,
 			startDate INTEGER,
+			startBucket INTEGER,
 			deadline INTEGER,
 			deadlineSuppressionDate INTEGER,
 			creationDate REAL,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -44,6 +44,7 @@ type Task struct {
 	Notes        string          `json:"notes,omitempty"`
 	Start        string          `json:"start,omitempty"`
 	StartDate    string          `json:"start_date,omitempty"`
+	StartBucket  *int            `json:"start_bucket,omitempty"`
 	Repeating    bool            `json:"repeating,omitempty"`
 	Deadline     string          `json:"deadline,omitempty"`
 	StopDate     string          `json:"stop_date,omitempty"`
@@ -72,18 +73,18 @@ type ChecklistItem struct {
 }
 
 type Item struct {
-	UUID         string `json:"uuid"`
-	Type         string `json:"type"`
-	Title        string `json:"title"`
-	Status       *int   `json:"status,omitempty"`
-	Trashed      *bool  `json:"trashed,omitempty"`
+	UUID         string          `json:"uuid"`
+	Type         string          `json:"type"`
+	Title        string          `json:"title"`
+	Status       *int            `json:"status,omitempty"`
+	Trashed      *bool           `json:"trashed,omitempty"`
 	Checklist    []ChecklistItem `json:"checklist,omitempty"`
-	ProjectTitle string `json:"project_title,omitempty"`
-	AreaTitle    string `json:"area_title,omitempty"`
-	HeadingTitle string `json:"heading_title,omitempty"`
-	Visible      *bool  `json:"visible,omitempty"`
-	Shortcut     string `json:"shortcut,omitempty"`
-	ParentID     string `json:"parent_id,omitempty"`
+	ProjectTitle string          `json:"project_title,omitempty"`
+	AreaTitle    string          `json:"area_title,omitempty"`
+	HeadingTitle string          `json:"heading_title,omitempty"`
+	Visible      *bool           `json:"visible,omitempty"`
+	Shortcut     string          `json:"shortcut,omitempty"`
+	ParentID     string          `json:"parent_id,omitempty"`
 }
 
 type TreeItem struct {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -609,7 +609,7 @@ func (s *Store) queryTasks(where string, args []any, filter TaskFilter, order st
 		return nil, fmt.Errorf("database not initialized")
 	}
 	var b strings.Builder
-	b.WriteString("SELECT t.uuid, t.type, t.title, t.status, t.trashed, t.notes, t.start, t.startDate, t.deadline, t.stopDate, t.creationDate, t.userModificationDate, t.\"index\", t.todayIndex, (t.rt1_recurrenceRule IS NOT NULL) AS repeating, ")
+	b.WriteString("SELECT t.uuid, t.type, t.title, t.status, t.trashed, t.notes, t.start, t.startDate, t.startBucket, t.deadline, t.stopDate, t.creationDate, t.userModificationDate, t.\"index\", t.todayIndex, (t.rt1_recurrenceRule IS NOT NULL) AS repeating, ")
 	b.WriteString("t.project, p.title, t.area, a.title, t.heading, h.title, ")
 	b.WriteString("(SELECT group_concat(title, '" + tagSeparator + "') FROM (")
 	b.WriteString("SELECT tag.title AS title FROM TMTag tag ")
@@ -757,6 +757,7 @@ func scanTaskRows(rows *sql.Rows) ([]Task, error) {
 		var notes sql.NullString
 		var start sql.NullInt64
 		var startDate sql.NullInt64
+		var startBucket sql.NullInt64
 		var deadline sql.NullInt64
 		var stopDate sql.NullFloat64
 		var created sql.NullFloat64
@@ -771,7 +772,7 @@ func scanTaskRows(rows *sql.Rows) ([]Task, error) {
 		var headingID sql.NullString
 		var headingTitle sql.NullString
 		var tagTitles sql.NullString
-		if err := rows.Scan(&t.UUID, &taskType, &t.Title, &t.Status, &t.Trashed, &notes, &start, &startDate, &deadline, &stopDate, &created, &modified, &index, &todayIndex, &repeating, &projectID, &projectTitle, &areaID, &areaTitle, &headingID, &headingTitle, &tagTitles); err != nil {
+		if err := rows.Scan(&t.UUID, &taskType, &t.Title, &t.Status, &t.Trashed, &notes, &start, &startDate, &startBucket, &deadline, &stopDate, &created, &modified, &index, &todayIndex, &repeating, &projectID, &projectTitle, &areaID, &areaTitle, &headingID, &headingTitle, &tagTitles); err != nil {
 			return nil, err
 		}
 		t.Type = taskTypeLabel(taskType)
@@ -793,6 +794,10 @@ func scanTaskRows(rows *sql.Rows) ([]Task, error) {
 		}
 		if startDate.Valid {
 			t.StartDate = formatThingsDate(startDate.Int64)
+		}
+		if startBucket.Valid {
+			val := int(startBucket.Int64)
+			t.StartBucket = &val
 		}
 		if deadline.Valid {
 			t.Deadline = formatThingsDate(deadline.Int64)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -125,6 +125,7 @@ func seedTestDB(conn *sql.DB) error {
 			heading TEXT,
 			start INTEGER,
 			startDate INTEGER,
+			startBucket INTEGER,
 			deadline INTEGER,
 			deadlineSuppressionDate INTEGER,
 			creationDate REAL,

--- a/internal/db/today_test.go
+++ b/internal/db/today_test.go
@@ -25,11 +25,15 @@ func TestTodayTasks(t *testing.T) {
 	}
 
 	titles := make(map[string]bool)
+	buckets := make(map[string]int)
 	for _, task := range tasks {
 		titles[task.Title] = true
+		if task.StartBucket != nil {
+			buckets[task.Title] = *task.StartBucket
+		}
 	}
 
-	for _, want := range []string{"Anytime Today", "Someday Past", "Overdue"} {
+	for _, want := range []string{"Anytime Today", "This Evening", "Someday Past", "Overdue"} {
 		if !titles[want] {
 			t.Fatalf("expected task %q in results", want)
 		}
@@ -38,6 +42,12 @@ func TestTodayTasks(t *testing.T) {
 		if titles[unwanted] {
 			t.Fatalf("did not expect task %q in results", unwanted)
 		}
+	}
+	if buckets["Anytime Today"] != 0 {
+		t.Fatalf("expected Anytime Today start bucket 0, got %d", buckets["Anytime Today"])
+	}
+	if buckets["This Evening"] != 1 {
+		t.Fatalf("expected This Evening start bucket 1, got %d", buckets["This Evening"])
 	}
 }
 
@@ -55,6 +65,7 @@ func seedTodayDB(conn *sql.DB) error {
 			heading TEXT,
 			start INTEGER,
 			startDate INTEGER,
+			startBucket INTEGER,
 			deadline INTEGER,
 			deadlineSuppressionDate INTEGER,
 			creationDate REAL,
@@ -77,31 +88,35 @@ func seedTodayDB(conn *sql.DB) error {
 	today := thingsDate(time.Now())
 	yesterday := thingsDate(time.Now().AddDate(0, 0, -1))
 	future := thingsDate(time.Now().AddDate(0, 0, 2))
+	todayBucket := 0
+	eveningBucket := 1
 
 	inserts := []struct {
-		uuid       string
-		title      string
-		start      int
-		startDate  *int
-		deadline   *int
-		deadSuppr  *int
-		status     int
-		trashed    int
-		index      *int
-		recurrence *string
+		uuid        string
+		title       string
+		start       int
+		startDate   *int
+		startBucket *int
+		deadline    *int
+		deadSuppr   *int
+		status      int
+		trashed     int
+		index       *int
+		recurrence  *string
 	}{
-		{"T1", "Anytime Today", 1, &today, nil, nil, StatusIncomplete, 0, nil, nil},
-		{"T2", "Someday Past", 2, &yesterday, nil, nil, StatusIncomplete, 0, nil, nil},
-		{"T3", "Overdue", 1, nil, &yesterday, nil, StatusIncomplete, 0, nil, nil},
-		{"T4", "Suppressed Deadline", 1, nil, &yesterday, intPtr(1), StatusIncomplete, 0, nil, nil},
-		{"T5", "Someday Future", 2, &future, nil, nil, StatusIncomplete, 0, nil, nil},
-		{"T6", "Completed Today", 1, &today, nil, nil, StatusCompleted, 0, nil, nil},
+		{"T1", "Anytime Today", 1, &today, &todayBucket, nil, nil, StatusIncomplete, 0, nil, nil},
+		{"T2", "Someday Past", 2, &yesterday, nil, nil, nil, StatusIncomplete, 0, nil, nil},
+		{"T3", "Overdue", 1, nil, nil, &yesterday, nil, StatusIncomplete, 0, nil, nil},
+		{"T4", "Suppressed Deadline", 1, nil, nil, &yesterday, intPtr(1), StatusIncomplete, 0, nil, nil},
+		{"T5", "Someday Future", 2, &future, nil, nil, nil, StatusIncomplete, 0, nil, nil},
+		{"T6", "Completed Today", 1, &today, nil, nil, nil, StatusCompleted, 0, nil, nil},
+		{"T7", "This Evening", 1, &today, &eveningBucket, nil, nil, StatusIncomplete, 0, nil, nil},
 	}
 
 	for _, item := range inserts {
 		_, err := conn.Exec(
-			`INSERT INTO TMTask (uuid, type, status, trashed, title, start, startDate, deadline, deadlineSuppressionDate, todayIndex, rt1_recurrenceRule)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			`INSERT INTO TMTask (uuid, type, status, trashed, title, start, startDate, startBucket, deadline, deadlineSuppressionDate, todayIndex, rt1_recurrenceRule)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			item.uuid,
 			TaskTypeTodo,
 			item.status,
@@ -109,6 +124,7 @@ func seedTodayDB(conn *sql.DB) error {
 			item.title,
 			item.start,
 			item.startDate,
+			item.startBucket,
 			item.deadline,
 			item.deadSuppr,
 			item.index,


### PR DESCRIPTION
## Summary
- expose start_bucket on task output data so `things today` can distinguish Today vs This Evening items
- include t.startBucket in the shared task query/scan path
- add start_bucket as a selectable output field (`--select start_bucket`) and aliases
- expand today tests to assert bucket values and update in-memory test schemas

## Testing
- go test ./...

Fixes #11