### PR TITLE
fix: accept Things database directories

### DIFF
--- a/internal/db/path.go
+++ b/internal/db/path.go
@@ -11,15 +11,17 @@ import (
 
 var ErrDatabaseNotFound = errors.New("things database not found")
 
+const thingsDatabaseFile = "main.sqlite"
+
 // ResolveDatabasePath finds the Things database path.
 //
 // Priority: override arg, THINGSDB env, default ThingsData-* locations, legacy path.
 func ResolveDatabasePath(override string) (string, error) {
 	if override != "" {
-		return expandHome(override), nil
+		return normalizeDatabasePath(expandHome(override))
 	}
 	if env := strings.TrimSpace(os.Getenv("THINGSDB")); env != "" {
-		return expandHome(env), nil
+		return normalizeDatabasePath(expandHome(env))
 	}
 
 	home, err := os.UserHomeDir()
@@ -27,7 +29,7 @@ func ResolveDatabasePath(override string) (string, error) {
 		return "", fmt.Errorf("resolve home directory: %w", err)
 	}
 
-	pattern := filepath.Join(home, "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac", "ThingsData-*", "Things Database.thingsdatabase", "main.sqlite")
+	pattern := filepath.Join(home, "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac", "ThingsData-*", "Things Database.thingsdatabase", thingsDatabaseFile)
 	matches, _ := filepath.Glob(pattern)
 	if len(matches) > 0 {
 		if path := newestFile(matches); path != "" {
@@ -35,12 +37,36 @@ func ResolveDatabasePath(override string) (string, error) {
 		}
 	}
 
-	legacy := filepath.Join(home, "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac", "Things Database.thingsdatabase", "main.sqlite")
+	legacy := filepath.Join(home, "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac", "Things Database.thingsdatabase", thingsDatabaseFile)
 	if fileExists(legacy) {
 		return legacy, nil
 	}
 
 	return "", ErrDatabaseNotFound
+}
+
+func normalizeDatabasePath(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return path, nil
+	}
+	if !info.IsDir() {
+		return path, nil
+	}
+
+	if filepath.Base(path) == "Things Database.thingsdatabase" {
+		candidate := filepath.Join(path, thingsDatabaseFile)
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		return "", fmt.Errorf("things database file not found in %s", path)
+	}
+
+	candidate := filepath.Join(path, "Things Database.thingsdatabase", thingsDatabaseFile)
+	if fileExists(candidate) {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("expected Things database file, got directory %s", path)
 }
 
 func expandHome(path string) string {

--- a/internal/db/path_test.go
+++ b/internal/db/path_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveDatabasePathNormalizesThingsDataDirectory(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "Things Database.thingsdatabase", thingsDatabaseFile)
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create database bundle: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatalf("write database file: %v", err)
+	}
+
+	got, err := ResolveDatabasePath(root)
+	if err != nil {
+		t.Fatalf("resolve database path: %v", err)
+	}
+	if got != dbPath {
+		t.Fatalf("expected %q, got %q", dbPath, got)
+	}
+}
+
+func TestResolveDatabasePathNormalizesThingsDatabaseDirectory(t *testing.T) {
+	root := t.TempDir()
+	bundle := filepath.Join(root, "Things Database.thingsdatabase")
+	dbPath := filepath.Join(bundle, thingsDatabaseFile)
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("create database bundle: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("sqlite"), 0o644); err != nil {
+		t.Fatalf("write database file: %v", err)
+	}
+
+	got, err := ResolveDatabasePath(bundle)
+	if err != nil {
+		t.Fatalf("resolve database path: %v", err)
+	}
+	if got != dbPath {
+		t.Fatalf("expected %q, got %q", dbPath, got)
+	}
+}
+
+func TestResolveDatabasePathRejectsDirectoryWithoutDatabase(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := ResolveDatabasePath(root)
+	if err == nil {
+		t.Fatalf("expected directory error, got path %q", got)
+	}
+	if !strings.Contains(err.Error(), "expected Things database file") {
+		t.Fatalf("expected clear directory error, got %v", err)
+	}
+}

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -44,7 +44,7 @@ Repeating (database writes)
  - Repeating adds launch Things in the background first to ensure the item hits the database before the repeat rule is applied.
 
 Filters + DB
-- Use `--db` or `THINGSDB` to point to a specific Things.sqlite.
+- Use `--db` or `THINGSDB` to point to a specific Things database. Accepted forms: the `main.sqlite` file, the `Things Database.thingsdatabase` directory, or the parent `ThingsData-*` directory.
 - Common filters: `--filter-project`, `--filter-area`, `--filter-tag`, `--status`, `--search`, `--limit`, `--offset`.
 - Rich query: `--query` supports boolean ops, field predicates, and regex (e.g. `title:/regex/ AND tag:work`).
 - Repeating tasks: `things repeating` or `--query 'repeating:true'`.


### PR DESCRIPTION
## Summary
- Normalize --db and THINGSDB when they point at a ThingsData-* directory or Things Database.thingsdatabase bundle
- Return a clear error for directories that do not contain a Things database file
- Update the in-repo Things skill guidance with the accepted database path forms

Fixes #6

## Testing
- make test
- go run ./cmd/things inbox --limit 1 --db "$HOME/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-VEDL5"