### PR TITLE
[codex] Add checklist item status updates

### DIFF
--- a/.codex/skills/release-flow/SKILL.md
+++ b/.codex/skills/release-flow/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: release-flow
+description: Maintainer release workflow for things3-cli. Use when preparing, validating, tagging, publishing, or verifying a public things3-cli release or Homebrew formula update.
+---
+
+# release-flow
+
+Use this skill when shipping `things3-cli` to external users and agents.
+
+Start here:
+- Read `docs/RELEASING.md`.
+- Read `references/release-flow.md` for the validation sequence and command details.
+
+Core rule:
+- Do not publish a release from assumptions. Verify tests, artifacts, changelog notes, formula checksums, GitHub release assets, and the installed binary path before calling the release done.
+
+Quick path:
+1. Confirm the working tree and release version.
+2. Move `CHANGELOG.md` entries from `Unreleased` into `vX.Y.Z` with today's date.
+3. Run `make test`.
+4. Build artifacts with `./scripts/build-release.sh vX.Y.Z`.
+5. Update the formula with `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`.
+6. Verify release notes with `./scripts/release-notes.sh vX.Y.Z`.
+7. Commit the changelog/formula/docs changes.
+8. Tag and publish with either the GitHub Actions release workflow or `./scripts/release.sh vX.Y.Z`.
+9. Verify the GitHub release and Homebrew install path.
+
+When CLI behavior changes, also update `skills/things/SKILL.md` and the mirrored `../agent-scripts/archived-skills/things/SKILL.md` if that mirror exists.

--- a/.codex/skills/release-flow/references/release-flow.md
+++ b/.codex/skills/release-flow/references/release-flow.md
@@ -1,0 +1,108 @@
+# things3-cli Release Flow
+
+This repo is consumed by external users and agents. Treat releases as public API changes.
+
+## Preconditions
+
+- Work from `main`.
+- Check `git status --short`; release scripts require a clean tree for publish.
+- Confirm the next version from `CHANGELOG.md`, `git tag --sort=-version:refname`, and the scope of the change.
+- Prefer SemVer:
+  - patch for bug fixes and docs-only release support,
+  - minor for new flags, commands, or output fields,
+  - major for breaking command/output behavior.
+
+## Required Validation
+
+Run these before publishing:
+
+```sh
+make test
+./scripts/build-release.sh vX.Y.Z
+./scripts/release-notes.sh vX.Y.Z
+```
+
+Check the generated artifacts:
+
+```sh
+ls -la dist
+cat dist/checksums.txt
+tmpdir=$(mktemp -d)
+tar -xzf dist/things-X.Y.Z-darwin-arm64.tar.gz -C "$tmpdir"
+"$tmpdir/things" --version
+rm -rf "$tmpdir"
+```
+
+## Changelog
+
+Move `CHANGELOG.md` entries out of `Unreleased` into:
+
+```md
+## [X.Y.Z] - YYYY-MM-DD
+```
+
+The GitHub release body must be only the bullets for that version. `./scripts/release-notes.sh vX.Y.Z` is the source of truth.
+
+## Homebrew Formula
+
+Update the formula after artifacts exist:
+
+```sh
+./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap
+```
+
+Validate:
+
+```sh
+rg -n 'version "|download/v|sha256' Formula/things3-cli.rb ~/Developer/homebrew-tap/Formula/things3-cli.rb
+```
+
+After the GitHub release is live, verify install/upgrade from the tap when practical:
+
+```sh
+brew update
+brew reinstall ossianhempel/tap/things3-cli
+things --version
+```
+
+Do not claim Homebrew is ready until the formula references the released tag and tarball checksums.
+
+## Publishing
+
+Local publish:
+
+```sh
+./scripts/release.sh vX.Y.Z
+```
+
+CI publish:
+
+```sh
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The release workflow also runs tests, builds artifacts, generates notes, and publishes the GitHub release.
+
+## Post-Release Verification
+
+Verify:
+
+- GitHub release title is `things3-cli vX.Y.Z`.
+- Release body contains only that version's changelog bullets.
+- Assets include both darwin tarballs and `checksums.txt`.
+- Formula version, URLs, and checksums point to the released version.
+- Installed `things --version` reports `vX.Y.Z`.
+
+## Agent Skill Sync
+
+If command behavior changed, update:
+
+- `skills/things/SKILL.md`
+- `../agent-scripts/archived-skills/things/SKILL.md` when that mirror exists
+
+If release mechanics changed, update:
+
+- `.codex/skills/release-flow/SKILL.md`
+- `.codex/skills/release-flow/references/release-flow.md`
+- `docs/RELEASING.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,10 @@
 
 ## Agent Scripts / Skills Sync
 - Keep the in-repo skill mirror at `skills/things/SKILL.md` in sync with
-  `../agent-scripts/skills/things/SKILL.md`.
+  `../agent-scripts/archived-skills/things/SKILL.md`.
 - After CLI changes, update both copies so agent guidance stays aligned.
+- Use `.codex/skills/release-flow/SKILL.md` for public release prep,
+  validation, Homebrew formula updates, and GitHub release verification.
+- If release mechanics change, update `.codex/skills/release-flow/SKILL.md`,
+  `.codex/skills/release-flow/references/release-flow.md`, and
+  `docs/RELEASING.md` together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, and this project adheres to
 Semantic Versioning.
 
 ## [Unreleased]
+- Added `update --complete-checklist-item` and `--incomplete-checklist-item`
+  to change existing checklist item completion status via the Things JSON URL
+  endpoint.
 
 ## [0.2.1] - 2026-04-20
 - Accept `ThingsData-*` and `Things Database.thingsdatabase` directories in `--db` and `THINGSDB`.

--- a/README.md
+++ b/README.md
@@ -108,15 +108,21 @@ Examples:
 things add "Daily standup" --repeat=day --repeat-mode=schedule
 things update --id <uuid> --repeat=week --repeat-every=2
 things update --id <uuid> --repeat-clear
+things update --id <uuid> --complete-checklist-item "Book hotel"
+things update --id <uuid> --incomplete-checklist-item "Book hotel"
 ```
 
-## Agent Skill
+## Agent Skills
 
 This repo includes a Things agent skill at `skills/things/SKILL.md`.
 
-That file is mirrored to `../agent-scripts/skills/things/SKILL.md` so local
-agent setups can consume the same guidance. Keep both copies in sync when
-commands or behavior change.
+That file is mirrored to `../agent-scripts/archived-skills/things/SKILL.md` so
+local agent setups can consume the same guidance. Keep both copies in sync
+when commands or behavior change.
+
+Maintainer release guidance lives in `.codex/skills/release-flow/SKILL.md` and
+`docs/RELEASING.md`. Use it when preparing a public release or updating the
+Homebrew formula.
 
 ## Notes
 

--- a/doc/man/things.1.md
+++ b/doc/man/things.1.md
@@ -401,6 +401,16 @@ This Evening.
   todo (maximum of 100). Can be specified multiple times on the command
   line.
 
+*--complete-checklist-item=ITEM*
+  Mark an existing checklist item complete by exact title. Requires
+  `--id` and cannot be combined with other update fields. Can be
+  specified multiple times on the command line.
+
+*--incomplete-checklist-item=ITEM*
+  Mark an existing checklist item incomplete by exact title. Requires
+  `--id` and cannot be combined with other update fields. Can be
+  specified multiple times on the command line.
+
 *--repeat=UNIT*
   Set a repeating schedule. Units: day, week, month, year.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,18 +11,29 @@ read_when:
 
 - Title every GitHub release as `things3-cli <version>`.
 - Release body = the CHANGELOG bullets for that version only (no extra prose).
+- Do not call a release complete until tests, artifacts, release notes,
+  Homebrew formula checksums, GitHub release assets, and the installed binary
+  version have been verified.
 
 ## Checklist
 
+- [ ] Confirm you are on `main`, the working tree is clean or only contains the
+      intended release edits, and the next version matches SemVer scope.
 - [ ] Update `CHANGELOG.md`: move items from **Unreleased** into a new version section with today’s date.
 - [ ] Run tests: `make test`.
 - [ ] Build release artifacts: `./scripts/build-release.sh vX.Y.Z`.
+- [ ] Smoke-test an artifact binary and confirm `things --version` reports `vX.Y.Z`.
 - [ ] Update Homebrew formula:
   `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`
   (commits to `Formula/` and copies into the tap repo).
+- [ ] Verify `Formula/things3-cli.rb` and the tap formula point at the new
+      release URLs and checksums.
 - [ ] Generate release notes: `./scripts/release-notes.sh vX.Y.Z` (should output only the changelog bullets).
-- [ ] Tag the release: `git tag vX.Y.Z` then `git push --tags`.
+- [ ] Commit the changelog/formula/docs changes.
+- [ ] Tag the release: `git tag vX.Y.Z` then `git push origin vX.Y.Z`.
 - [ ] Create the GitHub release:
   - Option A (local): `./scripts/release.sh vX.Y.Z`
   - Option B (CI): push the tag and let `.github/workflows/release.yml` publish the release
 - [ ] Verify the GitHub release title, notes, and assets match the guardrails.
+- [ ] Verify Homebrew install or reinstall from `ossianhempel/tap/things3-cli`
+      and confirm `things --version`.

--- a/integration/update_test.go
+++ b/integration/update_test.go
@@ -147,6 +147,25 @@ func TestUpdatePrependChecklistItemsOption(t *testing.T) {
 	assertContains(t, out, "prepend-checklist-items="+join(enc("ITEM 1"), enc("ITEM 2")))
 }
 
+func TestUpdateCompleteChecklistItemOption(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "update", "--db", dbPath, "--auth-token=token", "--id=T1", "--complete-checklist-item=Check Item")
+	requireSuccess(t, code)
+	assertContains(t, out, "things:///json?")
+	assertContains(t, out, "auth-token=token")
+	assertContains(t, out, enc(`"completed":true`))
+	assertContains(t, out, enc(`"title":"Check Item"`))
+}
+
+func TestUpdateIncompleteChecklistItemOption(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "update", "--db", dbPath, "--auth-token=token", "--id=T1", "--incomplete-checklist-item=Check Item")
+	requireSuccess(t, code)
+	assertContains(t, out, "things:///json?")
+	assertNotContains(t, out, enc(`"completed":true`))
+	assertContains(t, out, enc(`"title":"Check Item"`))
+}
+
 func TestUpdateAddTagsOption(t *testing.T) {
 	out, _, code := runThings(t, "", "update", "--auth-token=token", "--id=1", "--add-tags=tag1,tag 3,tag2")
 	requireSuccess(t, code)

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -2047,6 +2047,16 @@ OPTIONS
     todo (maximum of 100). Can be specified multiple times on the command
     line.
 
+  --complete-checklist-item=ITEM
+    Mark an existing checklist item complete by exact title. Requires
+    --id and cannot be combined with other update fields. Can be specified
+    multiple times on the command line.
+
+  --incomplete-checklist-item=ITEM
+    Mark an existing checklist item incomplete by exact title. Requires
+    --id and cannot be combined with other update fields. Can be specified
+    multiple times on the command line.
+
   --repeat=UNIT
     Set a repeating schedule. Units: day, week, month, year.
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -65,6 +65,9 @@ func NewUpdateCommand(app *App) *cobra.Command {
 			}
 
 			if strings.TrimSpace(opts.ID) == "" {
+				if hasChecklistStatusChanges(opts) {
+					return fmt.Errorf("Error: checklist item status updates require --id")
+				}
 				if !hasExplicitSelector(map[string]bool{"status": changedStatus}, queryOpts) {
 					if err := ensureAuth(); err != nil {
 						return err
@@ -145,6 +148,47 @@ func NewUpdateCommand(app *App) *cobra.Command {
 			}
 
 			hasChanges := hasTodoUpdateChanges(opts, rawInput)
+			if hasChecklistStatusChanges(opts) {
+				if repeatSpec.Enabled {
+					return fmt.Errorf("Error: checklist item status updates cannot be combined with --repeat")
+				}
+				if hasChangesWithoutChecklistStatus(opts, rawInput) {
+					return fmt.Errorf("Error: checklist item status updates cannot be combined with other update fields")
+				}
+				if err := ensureAuth(); err != nil {
+					return err
+				}
+				store, _, err := db.OpenDefault(dbPath)
+				if err != nil {
+					return formatDBError(err)
+				}
+				defer store.Close()
+				task, err := store.TaskByID(opts.ID)
+				if err != nil {
+					return formatDBError(err)
+				}
+				checklist := make([]things.ChecklistItemState, 0, len(task.Checklist))
+				for _, item := range task.Checklist {
+					checklist = append(checklist, things.ChecklistItemState{
+						Title:  item.Title,
+						Status: item.Status,
+					})
+				}
+				url, err := things.BuildChecklistStatusUpdateURL(opts, checklist)
+				if err != nil {
+					return err
+				}
+				if !app.DryRun {
+					entry := ActionEntry{
+						Type:  ActionUpdate,
+						Items: []ActionItem{taskToActionItem(*task)},
+					}
+					if err := appendAction(entry); err != nil {
+						fmt.Fprintf(app.Err, "Warning: failed to write action log: %v\n", err)
+					}
+				}
+				return openURL(app, url)
+			}
 			if !repeatSpec.Enabled {
 				if err := ensureAuth(); err != nil {
 					return err
@@ -347,6 +391,8 @@ func NewUpdateCommand(app *App) *cobra.Command {
 	flags.StringArrayVar(&opts.ChecklistItems, "checklist-item", nil, "Checklist item (repeatable)")
 	flags.StringArrayVar(&opts.PrependChecklistItems, "prepend-checklist-item", nil, "Prepend checklist item (repeatable)")
 	flags.StringArrayVar(&opts.AppendChecklistItems, "append-checklist-item", nil, "Append checklist item (repeatable)")
+	flags.StringArrayVar(&opts.CompleteChecklistItems, "complete-checklist-item", nil, "Mark an existing checklist item complete by exact title (repeatable)")
+	flags.StringArrayVar(&opts.IncompleteChecklistItems, "incomplete-checklist-item", nil, "Mark an existing checklist item incomplete by exact title (repeatable)")
 	flags.BoolVar(&yes, "yes", false, "Confirm bulk update")
 	flags.BoolVar(&allowUnsafeTitle, "allow-unsafe-title", false, "Allow titles that look like flag assignments")
 	flags.BoolVar(&noVerify, "no-verify", false, "Skip verification of when updates against the Things database")
@@ -388,5 +434,19 @@ func hasTodoUpdateChanges(opts things.UpdateOptions, rawInput string) bool {
 	if len(opts.ChecklistItems) > 0 || len(opts.PrependChecklistItems) > 0 || len(opts.AppendChecklistItems) > 0 {
 		return true
 	}
+	if hasChecklistStatusChanges(opts) {
+		return true
+	}
 	return false
+}
+
+func hasChecklistStatusChanges(opts things.UpdateOptions) bool {
+	return len(opts.CompleteChecklistItems) > 0 || len(opts.IncompleteChecklistItems) > 0
+}
+
+func hasChangesWithoutChecklistStatus(opts things.UpdateOptions, rawInput string) bool {
+	withoutChecklistStatus := opts
+	withoutChecklistStatus.CompleteChecklistItems = nil
+	withoutChecklistStatus.IncompleteChecklistItems = nil
+	return hasTodoUpdateChanges(withoutChecklistStatus, rawInput)
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -171,3 +171,78 @@ func TestUpdateCommandAllowsEveningForNonTodayWithFlag(t *testing.T) {
 		t.Fatalf("expected open invocation")
 	}
 }
+
+func TestUpdateCommandCompletesChecklistItemViaJSON(t *testing.T) {
+	dbPath := writeTestDB(t)
+	launcher := &recordLauncher{}
+	app := &App{
+		In:       strings.NewReader(""),
+		Out:      &bytes.Buffer{},
+		Err:      &bytes.Buffer{},
+		Launcher: launcher,
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"update", "--db", dbPath, "--auth-token", "tok", "--id", "T1", "--complete-checklist-item", "Check Item"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	url := requireOpenURL(t, launcher)
+	if !strings.HasPrefix(url, "things:///json?") {
+		t.Fatalf("expected json url, got %q", url)
+	}
+	if !strings.Contains(url, "auth-token=tok") {
+		t.Fatalf("expected auth token in url, got %q", url)
+	}
+	if !strings.Contains(url, "completed%22%3Atrue") {
+		t.Fatalf("expected completed checklist payload, got %q", url)
+	}
+}
+
+func TestUpdateCommandChecklistStatusRequiresID(t *testing.T) {
+	launcher := &recordLauncher{}
+	app := &App{
+		In:       strings.NewReader(""),
+		Out:      &bytes.Buffer{},
+		Err:      &bytes.Buffer{},
+		Launcher: launcher,
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"update", "--auth-token", "tok", "--complete-checklist-item", "Check Item"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(launcher.args) != 0 {
+		t.Fatalf("expected no open invocation")
+	}
+}
+
+func TestUpdateCommandChecklistStatusRejectsOtherChanges(t *testing.T) {
+	dbPath := writeTestDB(t)
+	launcher := &recordLauncher{}
+	app := &App{
+		In:       strings.NewReader(""),
+		Out:      &bytes.Buffer{},
+		Err:      &bytes.Buffer{},
+		Launcher: launcher,
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"update", "--db", dbPath, "--auth-token", "tok", "--id", "T1", "--complete-checklist-item", "Check Item", "--notes", "Nope"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(launcher.args) != 0 {
+		t.Fatalf("expected no open invocation")
+	}
+}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -183,6 +183,7 @@ func (s *Store) TaskByID(id string) (*Task, error) {
 	filter := TaskFilter{
 		IncludeTrashed:        true,
 		ExcludeTrashedContext: false,
+		IncludeChecklist:      true,
 	}
 	tasks, err := s.queryTasks("t.uuid = ?", []any{id}, filter, "")
 	if err != nil {

--- a/internal/things/update.go
+++ b/internal/things/update.go
@@ -1,31 +1,43 @@
 package things
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
 
 // UpdateOptions defines options for update.
 type UpdateOptions struct {
-	AuthToken             string
-	ID                    string
-	Notes                 string
-	PrependNotes          string
-	AppendNotes           string
-	When                  string
-	Later                 bool
-	Deadline              string
-	Tags                  string
-	AddTags               string
-	Completed             bool
-	Canceled              bool
-	Reveal                bool
-	Duplicate             bool
-	CompletionDate        string
-	CreationDate          string
-	Heading               string
-	List                  string
-	ListID                string
-	ChecklistItems        []string
-	PrependChecklistItems []string
-	AppendChecklistItems  []string
+	AuthToken                string
+	ID                       string
+	Notes                    string
+	PrependNotes             string
+	AppendNotes              string
+	When                     string
+	Later                    bool
+	Deadline                 string
+	Tags                     string
+	AddTags                  string
+	Completed                bool
+	Canceled                 bool
+	Reveal                   bool
+	Duplicate                bool
+	CompletionDate           string
+	CreationDate             string
+	Heading                  string
+	List                     string
+	ListID                   string
+	ChecklistItems           []string
+	PrependChecklistItems    []string
+	AppendChecklistItems     []string
+	CompleteChecklistItems   []string
+	IncompleteChecklistItems []string
+}
+
+// ChecklistItemState describes the checklist fields needed for JSON updates.
+type ChecklistItemState struct {
+	Title  string
+	Status int
 }
 
 // BuildUpdateURL builds a Things URL for the update command.
@@ -144,4 +156,96 @@ func BuildUpdateURL(opts UpdateOptions, rawInput string) (string, error) {
 	}
 
 	return "things:///update?" + strings.Join(params, "&") + "&", nil
+}
+
+// BuildChecklistStatusUpdateURL builds a Things JSON URL that replaces the
+// current checklist with the same titles and updated completion statuses.
+func BuildChecklistStatusUpdateURL(opts UpdateOptions, checklist []ChecklistItemState) (string, error) {
+	if opts.AuthToken == "" {
+		return "", ErrMissingAuthToken
+	}
+	if opts.ID == "" {
+		return "", errMissingID
+	}
+	updated, err := applyChecklistStatusChanges(checklist, opts.CompleteChecklistItems, opts.IncompleteChecklistItems)
+	if err != nil {
+		return "", err
+	}
+
+	operation := []map[string]any{
+		{
+			"type":      "to-do",
+			"operation": "update",
+			"id":        opts.ID,
+			"attributes": map[string]any{
+				"checklist-items": updated,
+			},
+		},
+	}
+	data, err := json.Marshal(operation)
+	if err != nil {
+		return "", err
+	}
+	return "things:///json?auth-token=" + URLEncode(opts.AuthToken) + "&data=" + URLEncode(string(data)) + "&", nil
+}
+
+func applyChecklistStatusChanges(checklist []ChecklistItemState, completeTitles, incompleteTitles []string) ([]map[string]any, error) {
+	if len(checklist) == 0 {
+		return nil, fmt.Errorf("Error: todo has no checklist items")
+	}
+	requested := make(map[string]bool, len(completeTitles)+len(incompleteTitles))
+	for _, title := range completeTitles {
+		if requested[title] {
+			return nil, fmt.Errorf("Error: checklist item %q was requested more than once", title)
+		}
+		requested[title] = true
+	}
+	for _, title := range incompleteTitles {
+		if requested[title] {
+			return nil, fmt.Errorf("Error: checklist item %q cannot be both complete and incomplete", title)
+		}
+		requested[title] = true
+	}
+
+	counts := make(map[string]int, len(checklist))
+	for _, item := range checklist {
+		counts[item.Title]++
+	}
+	for title := range requested {
+		switch counts[title] {
+		case 0:
+			return nil, fmt.Errorf("Error: checklist item %q not found", title)
+		case 1:
+		default:
+			return nil, fmt.Errorf("Error: checklist item %q is ambiguous (%d matches)", title, counts[title])
+		}
+	}
+
+	complete := make(map[string]bool, len(completeTitles))
+	for _, title := range completeTitles {
+		complete[title] = true
+	}
+	incomplete := make(map[string]bool, len(incompleteTitles))
+	for _, title := range incompleteTitles {
+		incomplete[title] = true
+	}
+
+	updated := make([]map[string]any, 0, len(checklist))
+	for _, item := range checklist {
+		attrs := map[string]any{"title": item.Title}
+		switch {
+		case complete[item.Title]:
+			attrs["completed"] = true
+		case incomplete[item.Title]:
+		case item.Status == 3:
+			attrs["completed"] = true
+		case item.Status == 2:
+			attrs["canceled"] = true
+		}
+		updated = append(updated, map[string]any{
+			"type":       "checklist-item",
+			"attributes": attrs,
+		})
+	}
+	return updated, nil
 }

--- a/internal/things/update_test.go
+++ b/internal/things/update_test.go
@@ -1,6 +1,8 @@
 package things
 
 import (
+	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -111,5 +113,83 @@ func TestBuildUpdateURLTrailingAmpersand(t *testing.T) {
 	}
 	if !strings.HasSuffix(url, "&") {
 		t.Fatalf("expected trailing ampersand in %q", url)
+	}
+}
+
+func TestBuildChecklistStatusUpdateURL(t *testing.T) {
+	built, err := BuildChecklistStatusUpdateURL(UpdateOptions{
+		AuthToken:                "tok",
+		ID:                       "id",
+		CompleteChecklistItems:   []string{"One"},
+		IncompleteChecklistItems: []string{"Two"},
+	}, []ChecklistItemState{
+		{Title: "One", Status: 0},
+		{Title: "Two", Status: 3},
+		{Title: "Three", Status: 3},
+		{Title: "Four", Status: 2},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(built, "things:///json?auth-token=tok&data=") {
+		t.Fatalf("expected json url, got %q", built)
+	}
+	encoded := strings.TrimSuffix(strings.TrimPrefix(built, "things:///json?auth-token=tok&data="), "&")
+	data, err := url.QueryUnescape(encoded)
+	if err != nil {
+		t.Fatalf("unescape data: %v", err)
+	}
+	var operations []map[string]any
+	if err := json.Unmarshal([]byte(data), &operations); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+	if got := operations[0]["operation"]; got != "update" {
+		t.Fatalf("expected update operation, got %#v", got)
+	}
+	attrs := operations[0]["attributes"].(map[string]any)
+	items := attrs["checklist-items"].([]any)
+	first := items[0].(map[string]any)["attributes"].(map[string]any)
+	if first["completed"] != true {
+		t.Fatalf("expected first item completed, got %#v", first)
+	}
+	second := items[1].(map[string]any)["attributes"].(map[string]any)
+	if _, ok := second["completed"]; ok {
+		t.Fatalf("expected second item incomplete, got %#v", second)
+	}
+	third := items[2].(map[string]any)["attributes"].(map[string]any)
+	if third["completed"] != true {
+		t.Fatalf("expected third item to preserve completed, got %#v", third)
+	}
+	fourth := items[3].(map[string]any)["attributes"].(map[string]any)
+	if fourth["canceled"] != true {
+		t.Fatalf("expected fourth item to preserve canceled, got %#v", fourth)
+	}
+}
+
+func TestBuildChecklistStatusUpdateURLRejectsMissingChecklistItem(t *testing.T) {
+	_, err := BuildChecklistStatusUpdateURL(UpdateOptions{
+		AuthToken:              "tok",
+		ID:                     "id",
+		CompleteChecklistItems: []string{"Missing"},
+	}, []ChecklistItemState{{Title: "One", Status: 0}})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != `Error: checklist item "Missing" not found` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildChecklistStatusUpdateURLRejectsAmbiguousChecklistItem(t *testing.T) {
+	_, err := BuildChecklistStatusUpdateURL(UpdateOptions{
+		AuthToken:              "tok",
+		ID:                     "id",
+		CompleteChecklistItems: []string{"One"},
+	}, []ChecklistItemState{{Title: "One", Status: 0}, {Title: "One", Status: 3}})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != `Error: checklist item "One" is ambiguous (2 matches)` {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/share/man/man1/things.1
+++ b/share/man/man1/things.1
@@ -480,6 +480,18 @@ todo (maximum of 100)\. Can be specified multiple times on the command
 line\.
 .LP
 .TP
+\fI\-\-complete\-checklist\-item\[eq]ITEM\fP
+Mark an existing checklist item complete by exact title\. Requires
+\fB--id\fR and cannot be combined with other update fields\. Can be
+specified multiple times on the command line\.
+.LP
+.TP
+\fI\-\-incomplete\-checklist\-item\[eq]ITEM\fP
+Mark an existing checklist item incomplete by exact title\. Requires
+\fB--id\fR and cannot be combined with other update fields\. Can be
+specified multiple times on the command line\.
+.LP
+.TP
 \fI\-\-repeat\[eq]UNIT\fP
 Set a repeating schedule\. Units: day, week, month, year\.
 .LP

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -22,6 +22,7 @@ Write (URL scheme)
 - Checklist items (repeat `--checklist-item` per item): `things add "My task" --checklist-item="Step 1" --checklist-item="Step 2" --checklist-item="Step 3"`
 - `things add-project "Project title" --area "Area Name"`
 - `things update --id <uuid> --notes "Updated notes"`
+- Checklist status by exact title: `things update --id <uuid> --complete-checklist-item "Step 1"` or `things update --id <uuid> --incomplete-checklist-item "Step 1"`
 - Bulk update (preview then apply): `things update --query 'tag:work' --dry-run` then `things update --query 'tag:work' --yes --tags "Work"`
 - `things update-project --id <uuid> "New project title"`
 - `things rename-project --id <uuid> --title "New project title"`


### PR DESCRIPTION
## Summary
- add update flags for completing and un-completing existing checklist items by exact title
- send checklist status changes through the Things JSON URL endpoint while preserving untouched checklist items
- add repo-local release-flow skill guidance and update release docs/agent guidance

## Validation
- make test
- live Things smoke test: created a test todo with four checklist items, then marked Step 3 and Step 4 complete via the new JSON update path and verified statuses with show --recursive --json