### PR TITLE
[codex] Clear notes with empty update flag

### DIFF
--- a/integration/update_project_test.go
+++ b/integration/update_project_test.go
@@ -79,6 +79,12 @@ func TestUpdateProjectNotesOption(t *testing.T) {
 	assertContains(t, out, "notes="+enc("NOTES NOTES"))
 }
 
+func TestUpdateProjectEmptyNotesOption(t *testing.T) {
+	out, _, code := runThings(t, "", "update-project", "--auth-token=token", "--id=1", "--notes=")
+	requireSuccess(t, code)
+	assertContains(t, out, "notes=")
+}
+
 func TestUpdateProjectAppendNotesOption(t *testing.T) {
 	out, _, code := runThings(t, "", "update-project", "--auth-token=token", "--id=1", "--append-notes=APPEND NOTES")
 	requireSuccess(t, code)

--- a/integration/update_test.go
+++ b/integration/update_test.go
@@ -111,6 +111,12 @@ func TestUpdateNotesOption(t *testing.T) {
 	assertContains(t, out, "notes="+enc("NOTES NOTES"))
 }
 
+func TestUpdateEmptyNotesOption(t *testing.T) {
+	out, _, code := runThings(t, "", "update", "--auth-token=token", "--id=1", "--notes=")
+	requireSuccess(t, code)
+	assertContains(t, out, "notes=")
+}
+
 func TestUpdateAppendNotesOption(t *testing.T) {
 	out, _, code := runThings(t, "", "update", "--auth-token=token", "--id=1", "--append-notes=APPEND NOTES")
 	requireSuccess(t, code)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -46,6 +46,7 @@ func NewUpdateCommand(app *App) *cobra.Command {
 			if err := validateWhenInput(opts.When); err != nil {
 				return err
 			}
+			opts.NotesSet = cmd.Flags().Changed("notes")
 			verifyWhen := resolveWhenValue(opts.When, opts.Later)
 			verifyWhenEnabled := verifyWhen != "" && !noVerify && !app.DryRun
 			guardEvening := strings.EqualFold(verifyWhen, "evening") && !allowNonToday
@@ -407,7 +408,7 @@ func hasTodoUpdateChanges(opts things.UpdateOptions, rawInput string) bool {
 	if strings.TrimSpace(rawInput) != "" {
 		return true
 	}
-	if opts.Notes != "" || opts.PrependNotes != "" || opts.AppendNotes != "" {
+	if opts.Notes != "" || opts.NotesSet || opts.PrependNotes != "" || opts.AppendNotes != "" {
 		return true
 	}
 	if opts.When != "" || opts.Later {

--- a/internal/cli/update_project.go
+++ b/internal/cli/update_project.go
@@ -25,6 +25,7 @@ func NewUpdateProjectCommand(app *App) *cobra.Command {
 			if err := validateWhenInput(opts.When); err != nil {
 				return err
 			}
+			opts.NotesSet = cmd.Flags().Changed("notes")
 
 			token, err := resolveAuthToken(app, opts.AuthToken)
 			if err != nil {

--- a/internal/things/update.go
+++ b/internal/things/update.go
@@ -11,6 +11,7 @@ type UpdateOptions struct {
 	AuthToken                string
 	ID                       string
 	Notes                    string
+	NotesSet                 bool
 	PrependNotes             string
 	AppendNotes              string
 	When                     string
@@ -51,11 +52,13 @@ func BuildUpdateURL(opts UpdateOptions, rawInput string) (string, error) {
 
 	var title string
 	notes := opts.Notes
+	notesSet := opts.NotesSet
 
 	if rawInput != "" {
 		if HasMultipleLines(rawInput) {
 			title = FindTitle(rawInput)
 			notes = FindNotes(rawInput)
+			notesSet = notes != ""
 		} else {
 			title = rawInput
 		}
@@ -131,7 +134,7 @@ func BuildUpdateURL(opts UpdateOptions, rawInput string) (string, error) {
 		params = append(params, "add-tags="+URLEncode(opts.AddTags))
 	}
 
-	if notes != "" {
+	if notes != "" || notesSet {
 		params = append(params, "notes="+URLEncode(notes))
 	}
 

--- a/internal/things/update_project.go
+++ b/internal/things/update_project.go
@@ -7,6 +7,7 @@ type UpdateProjectOptions struct {
 	AuthToken      string
 	ID             string
 	Notes          string
+	NotesSet       bool
 	PrependNotes   string
 	AppendNotes    string
 	When           string
@@ -35,11 +36,13 @@ func BuildUpdateProjectURL(opts UpdateProjectOptions, rawInput string) (string, 
 
 	var title string
 	notes := opts.Notes
+	notesSet := opts.NotesSet
 
 	if rawInput != "" {
 		if HasMultipleLines(rawInput) {
 			title = FindTitle(rawInput)
 			notes = FindNotes(rawInput)
+			notesSet = notes != ""
 		} else {
 			title = rawInput
 		}
@@ -93,7 +96,7 @@ func BuildUpdateProjectURL(opts UpdateProjectOptions, rawInput string) (string, 
 		params = append(params, "add-tags="+URLEncode(opts.AddTags))
 	}
 
-	if notes != "" {
+	if notes != "" || notesSet {
 		params = append(params, "notes="+URLEncode(notes))
 	}
 

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -22,6 +22,7 @@ Write (URL scheme)
 - Checklist items (repeat `--checklist-item` per item): `things add "My task" --checklist-item="Step 1" --checklist-item="Step 2" --checklist-item="Step 3"`
 - `things add-project "Project title" --area "Area Name"`
 - `things update --id <uuid> --notes "Updated notes"`
+- Clear notes by passing an explicit empty notes value: `things update --id <uuid> --notes ""`
 - Checklist status by exact title: `things update --id <uuid> --complete-checklist-item "Step 1"` or `things update --id <uuid> --incomplete-checklist-item "Step 1"`
 - Bulk update (preview then apply): `things update --query 'tag:work' --dry-run` then `things update --query 'tag:work' --yes --tags "Work"`
 - `things update-project --id <uuid> "New project title"`
@@ -63,6 +64,7 @@ Auth + permissions
 - Update `--when/--later` is verified against the database by default; use `--no-verify` to skip verification.
 - `--later` / `--when=evening` refuses to move tasks that are already scheduled for a non-today date; use `--allow-non-today` to override.
 - Titles that look like flag assignments (e.g. `tag=work`) are rejected; pass `--allow-unsafe-title` to keep them as the title.
+- For updates, an explicitly provided empty `--notes ""` clears notes; omitting `--notes` leaves notes unchanged.
 - Delete commands prompt for confirmation when interactive; pass `--confirm` for single deletes in non-interactive scripts. Query deletes require `--confirm=delete` or `--yes`.
 - Bulk update/delete write an action log; use `things undo` to revert the last bulk update or trash.
 


### PR DESCRIPTION
## Summary
- Treat explicitly provided empty `--notes` values as note replacement updates for todos and projects.
- Document `--notes ""` as the way to clear notes in the Things skill.

## Root cause
`--notes` was stored as a plain string, so an explicitly provided empty value was indistinguishable from an omitted flag. The URL builder skipped empty notes and Things left existing notes unchanged.

## Validation
- `make test`
