### PR TITLE
[codex] Add templates command for recurring task templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,16 @@
 - Unit tests live next to their packages (e.g., `internal/db/*_test.go`).
 - Integration tests live in `integration/` and include sqlite fixtures and helpers.
 - Run the full suite with `make test` or target a package with `go test ./internal/cli -run TestName`.
+- When Things 3 is available locally, verify user-facing CLI changes against the
+  real app/database in addition to fixtures. Prefer privacy-light smoke tests
+  for read-only commands, such as selecting only UUIDs or limiting output.
+- For write-path changes, create clearly named temporary Things items (for
+  example, prefixed with `things3-cli test`) that exercise the behavior, report
+  exactly what was created and verified, and then delete, complete, or otherwise
+  clean them up unless the developer explicitly wants to inspect them first.
+- If live verification is skipped because Things, Full Disk Access, automation
+  permission, or `THINGS_AUTH_TOKEN` is unavailable, call that out in the final
+  testing notes.
 
 ## Commit & Pull Request Guidelines
 - Recent commits use short, imperative summaries; common prefixes include `feat:`, `chore:`, and `docs:`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ brew install ossianhempel/tap/things3-cli
 - `today`            List today tasks
 - `upcoming`         List upcoming tasks
 - `repeating`        List repeating tasks
+- `templates`        List repeating template tasks
 - `anytime`          List anytime tasks
 - `someday`          List someday tasks
 - `logbook`          List logbook tasks
@@ -81,6 +82,7 @@ Things database to list content:
 - `things tags`      List tags
 - `things tasks`     List todos (with filters)
 - `things today`     List Today tasks
+- `things templates` List repeating template tasks
 - `things list-project-tasks --id <UUID>` List todos for a project
 
 By default it looks for the Things database in your user Library under the
@@ -96,6 +98,11 @@ Use `--repeat` flags with `add` or `update`
 to create or change repeating templates. These changes write directly to the
 Things database, so Full Disk Access is required. Repeating updates require a
 single explicit title (for add) or `--id` (for update).
+
+Use `things templates` to list the hidden template rows that control future
+instances of recurring todos. Template UUIDs can be passed to `things update`
+when you need to move or edit the source template rather than the visible
+generated instance.
 
 Supported patterns: every N day/week/month/year, in after-completion (default)
 or schedule mode. The anchor date controls weekday/month/day; multi-day weekly

--- a/integration/db_helpers_test.go
+++ b/integration/db_helpers_test.go
@@ -39,7 +39,9 @@ func writeTestDB(t *testing.T) string {
 			userModificationDate REAL,
 			stopDate REAL,
 			"index" INTEGER,
+			rt1_repeatingTemplate TEXT,
 			rt1_recurrenceRule BLOB,
+			repeater BLOB,
 			todayIndex INTEGER
 		);`,
 		`CREATE TABLE TMTag (uuid TEXT PRIMARY KEY, title TEXT, shortcut TEXT, parent TEXT);`,
@@ -124,6 +126,23 @@ func writeTestDB(t *testing.T) string {
 		); err != nil {
 			t.Fatalf("insert task %s: %v", item.uuid, err)
 		}
+	}
+
+	if _, err := conn.Exec(
+		`INSERT INTO TMTask (uuid, type, status, trashed, title, area, start, creationDate, rt1_recurrenceRule) VALUES ('TPL1', ?, ?, 0, 'Template Task', 'A1', 1, ?, X'01')`,
+		0,
+		0,
+		nowUnix,
+	); err != nil {
+		t.Fatalf("insert template task: %v", err)
+	}
+	if _, err := conn.Exec(
+		`INSERT INTO TMTask (uuid, type, status, trashed, title, area, start, creationDate, rt1_repeatingTemplate) VALUES ('GEN1', ?, ?, 0, 'Generated Template Instance', 'A1', 1, ?, 'TPL1')`,
+		0,
+		0,
+		nowUnix,
+	); err != nil {
+		t.Fatalf("insert generated repeating instance: %v", err)
 	}
 
 	return path

--- a/integration/list_commands_test.go
+++ b/integration/list_commands_test.go
@@ -30,6 +30,14 @@ func TestUpcomingCommand(t *testing.T) {
 	assertContains(t, out, "Upcoming Task")
 }
 
+func TestTemplatesCommand(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "templates", "--db", dbPath, "--area", "Home")
+	requireSuccess(t, code)
+	assertContains(t, out, "Template Task")
+	assertNotContains(t, out, "Generated Template Instance")
+}
+
 func TestDeadlinesCommand(t *testing.T) {
 	dbPath := writeTestDB(t)
 	out, _, code := runThings(t, "", "deadlines", "--db", dbPath)

--- a/internal/cli/dbtest_helpers_test.go
+++ b/internal/cli/dbtest_helpers_test.go
@@ -37,7 +37,9 @@ func writeTestDB(t *testing.T) string {
 			userModificationDate REAL,
 			stopDate REAL,
 			"index" INTEGER,
+			rt1_repeatingTemplate TEXT,
 			rt1_recurrenceRule BLOB,
+			repeater BLOB,
 			todayIndex INTEGER
 		);`,
 		`CREATE TABLE TMTag (uuid TEXT PRIMARY KEY, title TEXT, shortcut TEXT, parent TEXT);`,

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -30,6 +30,7 @@ COMMANDS
   today          - list today tasks from the Things database
   upcoming       - list upcoming tasks from the Things database
   repeating      - list repeating tasks from the Things database
+  templates      - list repeating template tasks from the Things database
   anytime        - list anytime tasks from the Things database
   someday        - list someday tasks from the Things database
   logbook        - list logbook tasks from the Things database
@@ -646,6 +647,101 @@ OPTIONS
     Suppress the header row.
 
 NOTES
+  The database lives in the Things app sandbox. You may need to grant your
+  terminal Full Disk Access to read it.
+`
+
+const templatesHelp = `Usage: things templates [OPTIONS...]
+
+NAME
+  things templates - list repeating template tasks from the Things database
+
+SYNOPSIS
+  things templates [OPTIONS...]
+
+DESCRIPTION
+  Lists hidden repeating template tasks using the local Things database
+  (read-only). These rows control where and how Things creates future
+  instances of recurring todos. By default only incomplete, non-trashed
+  templates are shown.
+
+OPTIONS
+  --db=PATH
+    Path to the Things database. Overrides the THINGSDB environment variable.
+
+  --status=STATUS
+    Filter by status: incomplete, completed, canceled, any. Default: incomplete.
+
+  --project=PROJECT
+    Filter by project title or ID.
+
+  --area=AREA
+    Filter by area title or ID.
+
+  --tag=TAG
+    Filter by tag title or ID.
+
+  --search=TEXT
+    Case-insensitive substring match on title or notes.
+
+  --query=QUERY
+    Rich query with boolean ops, fields, and regex (e.g. title:/regex/ AND tag:work).
+
+  --limit=N
+    Limit number of results (0 = no limit). Default: 200.
+
+  --offset=N
+    Offset results for pagination.
+
+  --created-after=DATE
+    Filter tasks created after (YYYY-MM-DD or RFC3339).
+
+  --created-before=DATE
+    Filter tasks created before (YYYY-MM-DD or RFC3339).
+
+  --modified-after=DATE
+    Filter tasks modified after (YYYY-MM-DD or RFC3339).
+
+  --modified-before=DATE
+    Filter tasks modified before (YYYY-MM-DD or RFC3339).
+
+  --due-before=DATE
+    Filter tasks due before (YYYY-MM-DD).
+
+  --start-before=DATE
+    Filter tasks starting before (YYYY-MM-DD).
+
+  --has-url
+    Filter tasks with URLs in notes.
+
+  --sort=FIELDS
+    Sort by fields (e.g. created,-deadline,title).
+
+  --recursive
+    Include checklist items in JSON output.
+
+  --include-trashed
+    Include trashed tasks.
+
+  --all
+    Include completed, canceled, and trashed tasks.
+
+  --format=FORMAT
+    Output format: table, json, jsonl, csv.
+
+  --select=FIELDS
+    Select fields (comma-separated).
+
+  --json
+    Output JSON (alias for --format json).
+
+  --no-header
+    Suppress the header row.
+
+NOTES
+  Template UUIDs can be passed to update commands, for example:
+    things update --id <uuid> --list "Property"
+
   The database lives in the Things app sandbox. You may need to grant your
   terminal Full Disk Access to read it.
 `

--- a/internal/cli/list_commands.go
+++ b/internal/cli/list_commands.go
@@ -72,6 +72,48 @@ func NewRepeatingCommand(app *App) *cobra.Command {
 	return cmd
 }
 
+func NewTemplatesCommand(app *App) *cobra.Command {
+	var dbPath string
+	opts := TaskQueryOptions{
+		Status: "incomplete",
+		Limit:  200,
+	}
+	var format string
+	var selectRaw string
+	var asJSON bool
+	var noHeader bool
+
+	cmd := &cobra.Command{
+		Use:   "templates",
+		Short: "List repeating template tasks from the Things database",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, _, err := db.OpenDefault(dbPath)
+			if err != nil {
+				return formatDBError(err)
+			}
+			defer store.Close()
+
+			opts.HasURLSet = cmd.Flags().Changed("has-url")
+			outputOpts, err := resolveTaskOutputOptions(format, asJSON, selectRaw, noHeader)
+			if err != nil {
+				return err
+			}
+			tasks, err := fetchTasks(store, store.TemplatesTasks, opts, false, []int{db.TaskTypeTodo})
+			if err != nil {
+				return formatDBError(err)
+			}
+			return printTasks(app.Out, tasks, outputOpts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&dbPath, "db", "d", "", "Path to Things database (overrides THINGSDB)")
+	cmd.Flags().StringVar(&dbPath, "database", "", "Alias for --db")
+	addTaskQueryFlags(cmd, &opts, true, true)
+	addTaskOutputFlags(cmd, &format, &selectRaw, &asJSON, &noHeader)
+
+	return cmd
+}
+
 func NewDeadlinesCommand(app *App) *cobra.Command {
 	return newTaskListCommand(app, "deadlines", "List tasks with deadlines from the Things database", "incomplete", func(store *db.Store, filter db.TaskFilter) ([]db.Task, error) {
 		return store.DeadlinesTasks(filter)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -42,6 +42,7 @@ func NewRoot(app *App) *cobra.Command {
 	cmd.AddCommand(NewTodayCommand(app))
 	cmd.AddCommand(NewUpcomingCommand(app))
 	cmd.AddCommand(NewRepeatingCommand(app))
+	cmd.AddCommand(NewTemplatesCommand(app))
 	cmd.AddCommand(NewAnytimeCommand(app))
 	cmd.AddCommand(NewSomedayCommand(app))
 	cmd.AddCommand(NewLogbookCommand(app))
@@ -94,6 +95,8 @@ func NewRoot(app *App) *cobra.Command {
 				printHelp(app.Out, formatHelpText(upcomingHelp, isTTY(app.Out)))
 			case "repeating":
 				printHelp(app.Out, formatHelpText(repeatingHelp, isTTY(app.Out)))
+			case "templates":
+				printHelp(app.Out, formatHelpText(templatesHelp, isTTY(app.Out)))
 			case "anytime":
 				printHelp(app.Out, formatHelpText(anytimeHelp, isTTY(app.Out)))
 			case "someday":
@@ -178,6 +181,8 @@ func NewRoot(app *App) *cobra.Command {
 			printHelp(app.Out, formatHelpText(upcomingHelp, isTTY(app.Out)))
 		case "repeating":
 			printHelp(app.Out, formatHelpText(repeatingHelp, isTTY(app.Out)))
+		case "templates":
+			printHelp(app.Out, formatHelpText(templatesHelp, isTTY(app.Out)))
 		case "anytime":
 			printHelp(app.Out, formatHelpText(anytimeHelp, isTTY(app.Out)))
 		case "someday":

--- a/internal/db/lists_test.go
+++ b/internal/db/lists_test.go
@@ -74,7 +74,9 @@ func seedListDB(conn *sql.DB) error {
 			userModificationDate REAL,
 			stopDate REAL,
 			"index" INTEGER,
+			rt1_repeatingTemplate TEXT,
 			rt1_recurrenceRule BLOB,
+			repeater BLOB,
 			todayIndex INTEGER
 		);`,
 		`CREATE TABLE TMChecklistItem (

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -175,6 +175,13 @@ func (s *Store) Tasks(filter TaskFilter) ([]Task, error) {
 	return s.queryTasks("", nil, filter, "")
 }
 
+// TemplatesTasks returns hidden repeating template tasks in the database.
+func (s *Store) TemplatesTasks(filter TaskFilter) ([]Task, error) {
+	filter.IncludeRepeating = true
+	where := "t.rt1_repeatingTemplate IS NULL AND (t.rt1_recurrenceRule IS NOT NULL OR t.repeater IS NOT NULL)"
+	return s.queryTasks(where, nil, filter, "")
+}
+
 // TaskByID returns a single task by UUID.
 func (s *Store) TaskByID(id string) (*Task, error) {
 	if strings.TrimSpace(id) == "" {
@@ -610,7 +617,7 @@ func (s *Store) queryTasks(where string, args []any, filter TaskFilter, order st
 		return nil, fmt.Errorf("database not initialized")
 	}
 	var b strings.Builder
-	b.WriteString("SELECT t.uuid, t.type, t.title, t.status, t.trashed, t.notes, t.start, t.startDate, t.startBucket, t.deadline, t.stopDate, t.creationDate, t.userModificationDate, t.\"index\", t.todayIndex, (t.rt1_recurrenceRule IS NOT NULL) AS repeating, ")
+	b.WriteString("SELECT t.uuid, t.type, t.title, t.status, t.trashed, t.notes, t.start, t.startDate, t.startBucket, t.deadline, t.stopDate, t.creationDate, t.userModificationDate, t.\"index\", t.todayIndex, (t.rt1_recurrenceRule IS NOT NULL OR t.repeater IS NOT NULL) AS repeating, ")
 	b.WriteString("t.project, p.title, t.area, a.title, t.heading, h.title, ")
 	b.WriteString("(SELECT group_concat(title, '" + tagSeparator + "') FROM (")
 	b.WriteString("SELECT tag.title AS title FROM TMTag tag ")
@@ -697,9 +704,9 @@ func (s *Store) queryTasks(where string, args []any, filter TaskFilter, order st
 		}
 	}
 	if filter.RepeatingOnly {
-		b.WriteString(" AND t.rt1_recurrenceRule IS NOT NULL")
+		b.WriteString(" AND (t.rt1_recurrenceRule IS NOT NULL OR t.repeater IS NOT NULL)")
 	} else if !filter.IncludeRepeating {
-		b.WriteString(" AND t.rt1_recurrenceRule IS NULL")
+		b.WriteString(" AND t.rt1_recurrenceRule IS NULL AND t.repeater IS NULL")
 	}
 
 	orderClause := order

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -80,6 +80,14 @@ func TestProjectsAndTasksQueries(t *testing.T) {
 		t.Fatalf("unexpected repeating tasks: %#v", repeating)
 	}
 
+	templates, err := store.TemplatesTasks(TaskFilter{Status: &status, ExcludeTrashedContext: true, Types: []int{TaskTypeTodo}})
+	if err != nil {
+		t.Fatalf("template tasks: %v", err)
+	}
+	if len(templates) != 1 || templates[0].Title != "Repeat Task" || !templates[0].Repeating {
+		t.Fatalf("unexpected template tasks: %#v", templates)
+	}
+
 	searched, err := store.Tasks(TaskFilter{Search: "notes", Status: &status, ExcludeTrashedContext: true, Types: []int{TaskTypeTodo}})
 	if err != nil {
 		t.Fatalf("search tasks: %v", err)
@@ -132,7 +140,9 @@ func seedTestDB(conn *sql.DB) error {
 			userModificationDate REAL,
 			stopDate REAL,
 			"index" INTEGER,
+			rt1_repeatingTemplate TEXT,
 			rt1_recurrenceRule BLOB,
+			repeater BLOB,
 			todayIndex INTEGER
 		);`,
 		`CREATE TABLE TMTag (uuid TEXT PRIMARY KEY, title TEXT, shortcut TEXT, parent TEXT);`,
@@ -170,6 +180,9 @@ func seedTestDB(conn *sql.DB) error {
 		return err
 	}
 	if _, err := conn.Exec(`INSERT INTO TMTask (uuid, type, status, trashed, title, project, area, heading, start, startDate, deadline, creationDate, userModificationDate, rt1_recurrenceRule) VALUES ('T2', ?, ?, 0, 'Repeat Task', 'P1', 'A1', 'H1', 1, ?, ?, ?, ?, X'01');`, TaskTypeTodo, StatusIncomplete, startDate, deadline, nowUnix, nowUnix); err != nil {
+		return err
+	}
+	if _, err := conn.Exec(`INSERT INTO TMTask (uuid, type, status, trashed, title, project, area, heading, start, startDate, deadline, creationDate, userModificationDate, rt1_repeatingTemplate) VALUES ('T3', ?, ?, 0, 'Generated Repeat Instance', 'P1', 'A1', 'H1', 1, ?, ?, ?, ?, 'T2');`, TaskTypeTodo, StatusCompleted, startDate, deadline, nowUnix, nowUnix); err != nil {
 		return err
 	}
 	if _, err := conn.Exec(`INSERT INTO TMTag (uuid, title) VALUES ('TAG1', 'urgent');`); err != nil {

--- a/internal/db/today_test.go
+++ b/internal/db/today_test.go
@@ -73,7 +73,9 @@ func seedTodayDB(conn *sql.DB) error {
 			stopDate REAL,
 			"index" INTEGER,
 			todayIndex INTEGER,
-			rt1_recurrenceRule TEXT
+			rt1_repeatingTemplate TEXT,
+			rt1_recurrenceRule TEXT,
+			repeater BLOB
 		);`,
 		`CREATE TABLE TMArea (uuid TEXT PRIMARY KEY, title TEXT, visible INTEGER, "index" INTEGER);`,
 		`CREATE TABLE TMTag (uuid TEXT PRIMARY KEY, title TEXT, shortcut TEXT, parent TEXT);`,

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -11,6 +11,7 @@ Quick start (read)
 - `things inbox`
 - `things today`
 - `things repeating`
+- `things templates`
 - `things projects` / `things areas` / `things tags`
 - `things tasks --search "query" --json`
 - `things tasks --query 'tag:work AND title:/review/i' --format jsonl`
@@ -49,6 +50,7 @@ Filters + DB
 - Common filters: `--filter-project`, `--filter-area`, `--filter-tag`, `--status`, `--search`, `--limit`, `--offset`.
 - Rich query: `--query` supports boolean ops, field predicates, and regex (e.g. `title:/regex/ AND tag:work`).
 - Repeating tasks: `things repeating` or `--query 'repeating:true'`.
+- Repeating templates: `things templates --area "Area Name"` lists hidden template rows that control future recurring instances.
 - Date filters: `--created-before/after`, `--modified-before/after`, `--due-before`, `--start-before`.
 - URL filter: `--has-url`.
 - Sorting: `--sort created,-deadline,title`.


### PR DESCRIPTION
## Summary

Adds a new `things templates` command for listing hidden recurring-task template rows from the Things database. These template rows control future generated instances, so surfacing them makes it possible to update the source template instead of only visible generated todos.

## What changed

- Added `Store.TemplatesTasks` and wired it through the shared task query/output pipeline.
- Registered `things templates` with the standard task query and output flags.
- Treats both `rt1_recurrenceRule` and `repeater` as repeating storage so current Things schemas are covered.
- Documents the command in help text, README, and the in-repo Things skill.
- Adds repository guidance to verify user-facing CLI changes against a real Things app/database when available.

## Validation

- `make test`
- Real Things database smoke test: `go run ./cmd/things templates --limit 1 --select uuid --no-header`

The live smoke test returned one UUID and avoided printing task titles or areas.