### PR TITLE
[codex] Include projects in search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install ossianhempel/tap/things3-cli
 - `rename-project`   Rename an existing project (requires auth token)
 - `delete-project`   Delete an existing project
 - `show`             Show an area, project, tag, or todo from the database (`--recursive` includes checklist items for todos)
-- `search`           Search tasks in the database
+- `search`           Search todos and projects in the database
 - `inbox`            List inbox tasks
 - `today`            List today tasks
 - `upcoming`         List upcoming tasks

--- a/integration/db_helpers_test.go
+++ b/integration/db_helpers_test.go
@@ -83,8 +83,14 @@ func writeTestDB(t *testing.T) string {
 	if _, err := conn.Exec(`INSERT INTO TMTag (uuid, title) VALUES ('TAG1', 'urgent');`); err != nil {
 		t.Fatalf("insert tag: %v", err)
 	}
+	if _, err := conn.Exec(`INSERT INTO TMTag (uuid, title) VALUES ('TAG_PLAN', 'PLAN');`); err != nil {
+		t.Fatalf("insert plan tag: %v", err)
+	}
 	if _, err := conn.Exec(`INSERT INTO TMTaskTag (tasks, tags) VALUES ('T1', 'TAG1');`); err != nil {
 		t.Fatalf("insert task tag: %v", err)
+	}
+	if _, err := conn.Exec(`INSERT INTO TMTaskTag (tasks, tags) VALUES ('P1', 'TAG_PLAN');`); err != nil {
+		t.Fatalf("insert project tag: %v", err)
 	}
 	if _, err := conn.Exec(`INSERT INTO TMChecklistItem (uuid, title, status, "index", task) VALUES ('C1', 'Check Item', 0, 0, 'T1');`); err != nil {
 		t.Fatalf("insert checklist: %v", err)

--- a/integration/search_test.go
+++ b/integration/search_test.go
@@ -15,3 +15,11 @@ func TestSearchAcceptsQueryFromStdin(t *testing.T) {
 	requireSuccess(t, code)
 	assertContains(t, out, "Task One")
 }
+
+func TestSearchRichQueryIncludesTaggedProjects(t *testing.T) {
+	dbPath := writeTestDB(t)
+	out, _, code := runThings(t, "", "search", "--db", dbPath, "--query", "tag:PLAN", "--select", "type,title")
+	requireSuccess(t, code)
+	assertContains(t, out, "project")
+	assertContains(t, out, "Project One")
+}

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -1897,13 +1897,13 @@ EXAMPLES
 const searchHelp = `Usage: things search [OPTIONS...] [--] <-|QUERY>
 
 NAME
-  things search - search tasks in the Things database
+  things search - search todos and projects in the Things database
 
 SYNOPSIS
   things search [--] <-|QUERY>
 
 DESCRIPTION
-  Searches tasks in the local Things database. The QUERY argument performs a
+  Searches todos and projects in the local Things database. The QUERY argument performs a
   case-insensitive substring search on title or notes. Use {{BT}}--query{{BT}}
   for rich queries with boolean ops, fields, and regex.
 
@@ -1987,6 +1987,8 @@ NOTES
 
 EXAMPLES
   things search "Work"
+
+  things search --query 'tag:PLAN' --select type,title
 
   echo "Home" | things search -
 `

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -22,7 +22,7 @@ func NewSearchCommand(app *App) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search [--] [-|QUERY]",
-		Short: "Search tasks in the Things database",
+		Short: "Search todos and projects in the Things database",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query, err := readInput(app.In, args)
 			if err != nil {
@@ -50,7 +50,7 @@ func NewSearchCommand(app *App) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tasks, err := fetchTasks(store, store.Tasks, opts, false, []int{db.TaskTypeTodo})
+			tasks, err := fetchTasks(store, store.Tasks, opts, false, []int{db.TaskTypeTodo, db.TaskTypeProject})
 			if err != nil {
 				return formatDBError(err)
 			}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -656,8 +656,8 @@ func (s *Store) queryTasks(where string, args []any, filter TaskFilter, order st
 		params = append(params, *filter.Status)
 	}
 	if filter.ProjectID != "" {
-		b.WriteString(" AND (t.project = ? OR hp.uuid = ?)")
-		params = append(params, filter.ProjectID, filter.ProjectID)
+		b.WriteString(" AND (t.uuid = ? OR t.project = ? OR hp.uuid = ?)")
+		params = append(params, filter.ProjectID, filter.ProjectID, filter.ProjectID)
 	}
 	if filter.AreaID != "" {
 		b.WriteString(" AND t.area = ?")

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -15,6 +15,7 @@ Quick start (read)
 - `things projects` / `things areas` / `things tags`
 - `things tasks --search "query" --json`
 - `things tasks --query 'tag:work AND title:/review/i' --format jsonl`
+- `things search --query 'tag:PLAN' --select type,title` searches both todos and projects.
 - `things show --project "Project Name"`
 - `things show --id <TODO_UUID> --recursive --json`
 


### PR DESCRIPTION
## Summary
- include project rows in things search results so rich tag queries can match tagged projects
- let mixed task/project queries include the selected project row when using project filters
- document the tag query syntax and add fixture-backed integration coverage

## Validation
- go test ./integration -run TestSearch
- make test
- codex-review --mode local --parallel-tests "make test"