### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ go.work.sum
 # .idea/
 # .vscode/
 bin/
+
+# Release build artifacts
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to
 Semantic Versioning.
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-05-26
+- Added `templates` command to list repeating template tasks from the Things database.
 - Added `update --complete-checklist-item` and `--incomplete-checklist-item`
   to change existing checklist item completion status via the Things JSON URL
   endpoint.
+- Clear task and project notes by passing an empty `--notes` value to `update` and `update-project`.
+- Include projects in `search` results.
 
 ## [0.2.1] - 2026-04-20
 - Accept `ThingsData-*` and `Things Database.thingsdatabase` directories in `--db` and `THINGSDB`.

--- a/Formula/things3-cli.rb
+++ b/Formula/things3-cli.rb
@@ -1,15 +1,15 @@
 class Things3Cli < Formula
   desc "CLI for Things 3"
   homepage "https://github.com/ossianhempel/things3-cli"
-  version "0.2.0"
+  version "0.3.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/ossianhempel/things3-cli/releases/download/v0.2.0/things-0.2.0-darwin-arm64.tar.gz"
-      sha256 "e6b84fee29e83cb39dc4b6a72480a6de05fc5876723dcc1f0a8e4e7c5f7f783f"
+      url "https://github.com/ossianhempel/things3-cli/releases/download/v0.3.0/things-0.3.0-darwin-arm64.tar.gz"
+      sha256 "4a87d9544f3a1357c1b7a335a3432bd2865a7f3181ae211260e1484ec3dd48b0"
     else
-      url "https://github.com/ossianhempel/things3-cli/releases/download/v0.2.0/things-0.2.0-darwin-amd64.tar.gz"
-      sha256 "ce9e1dadf7198c5c2f51d5eaf94f925110cf0170565e4066624802c2b104ca72"
+      url "https://github.com/ossianhempel/things3-cli/releases/download/v0.3.0/things-0.3.0-darwin-amd64.tar.gz"
+      sha256 "92d074d9d8de81e314b217a3a0f9de507f9ccede182725657bd30a229107e983"
     end
   end
 


### PR DESCRIPTION
Release prep for **v0.3.0** + release automation.

## v0.3.0 changelog
- Added `templates` command to list repeating template tasks
- Added `update --complete-checklist-item` / `--incomplete-checklist-item`
- Clear notes via empty `--notes` on `update` / `update-project`
- Include projects in `search` results

## Release automation (new)
- `.github/workflows/release.yml` now auto-releases on merge to `main`: when a
  commit adds a new `## [X.Y.Z]` CHANGELOG section, CI tags `vX.Y.Z` at the
  merge commit and publishes the GitHub release. Idempotent (skips if the tag
  exists); `workflow_dispatch` kept as manual override. **No more hand-tagging.**
- Homebrew tap stays out of CI by design — release docs/skill now make updating
  and pushing the tap an explicit agent-run step after the release is live, so
  the maintainer never does it manually.
- Bumped in-repo Homebrew formula 0.2.0 → 0.3.0; ignore `dist/` build artifacts.

## Validation
- `make test` ✅
- `./scripts/build-release.sh v0.3.0` ✅ — arm64 binary reports `v0.3.0`
- `./scripts/release-notes.sh v0.3.0` outputs only the changelog bullets ✅
- Formula checksums match built artifacts ✅
- Workflow YAML parses; CHANGELOG version detection returns `0.3.0` ✅

## What happens on merge
CI tags `v0.3.0` and publishes `things3-cli v0.3.0` automatically. After it's
live I update + push the `homebrew-tap` formula (already bumped here) and verify
the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)