### PR TITLE
fix: land release automation + correct v0.3.0 formula checksums

### DIFF
--- a/.codex/skills/release-flow/SKILL.md
+++ b/.codex/skills/release-flow/SKILL.md
@@ -16,20 +16,25 @@ Core rule:
 
 Tagging and the GitHub release are automated: merging a PR that adds a new
 `## [X.Y.Z]` section to `CHANGELOG.md` makes `.github/workflows/release.yml` tag
-and publish `vX.Y.Z`. Never tag by hand. The Homebrew tap is NOT in CI — the
-agent updates and pushes it after the release is live.
+and publish `vX.Y.Z`. Never tag by hand. The Homebrew formulas are NOT in CI —
+the agent regenerates them from the RELEASED checksums after the release is live
+(builds are not byte-reproducible, so locally built checksums will not match what
+users download).
 
 Quick path:
 1. Confirm the release version (SemVer scope of the merged changes).
 2. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` with the bullets.
-3. Build artifacts (`./scripts/build-release.sh vX.Y.Z`) and bump the in-repo
-   formula (`./scripts/update-brew-formula.sh --version vX.Y.Z`) so it ships in the PR.
-4. Run `make test`; smoke-test a built binary's `--version`.
-5. Sanity-check release notes with `./scripts/release-notes.sh vX.Y.Z`.
-6. Open a release PR and merge it — CI tags and publishes the release.
-7. After CI publishes, verify the GitHub release, then update and push the tap:
-   `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`
-   and commit + push `~/Developer/homebrew-tap`.
-8. Verify the Homebrew install path.
+   Do NOT bump the formula in this PR — its checksums aren't known yet.
+3. Run `make test`; build (`./scripts/build-release.sh vX.Y.Z`) and smoke-test a
+   built binary's `--version`.
+4. Sanity-check release notes with `./scripts/release-notes.sh vX.Y.Z`.
+5. Open a release PR and merge it — CI tags and publishes the release.
+6. After CI publishes, verify the GitHub release, then regenerate both formulas
+   from the released checksums:
+   `gh release download vX.Y.Z -p checksums.txt -O dist/checksums.txt --clobber`
+   then `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`.
+7. Commit + push `~/Developer/homebrew-tap`; open a follow-up PR for the in-repo
+   `Formula/things3-cli.rb`.
+8. Verify the Homebrew install path (`brew reinstall ossianhempel/tap/things3-cli`).
 
 When CLI behavior changes, also update `skills/things/SKILL.md` and the mirrored `../agent-scripts/archived-skills/things/SKILL.md` if that mirror exists.

--- a/.codex/skills/release-flow/SKILL.md
+++ b/.codex/skills/release-flow/SKILL.md
@@ -14,15 +14,22 @@ Start here:
 Core rule:
 - Do not publish a release from assumptions. Verify tests, artifacts, changelog notes, formula checksums, GitHub release assets, and the installed binary path before calling the release done.
 
+Tagging and the GitHub release are automated: merging a PR that adds a new
+`## [X.Y.Z]` section to `CHANGELOG.md` makes `.github/workflows/release.yml` tag
+and publish `vX.Y.Z`. Never tag by hand. The Homebrew tap is NOT in CI — the
+agent updates and pushes it after the release is live.
+
 Quick path:
-1. Confirm the working tree and release version.
-2. Move `CHANGELOG.md` entries from `Unreleased` into `vX.Y.Z` with today's date.
-3. Run `make test`.
-4. Build artifacts with `./scripts/build-release.sh vX.Y.Z`.
-5. Update the formula with `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`.
-6. Verify release notes with `./scripts/release-notes.sh vX.Y.Z`.
-7. Commit the changelog/formula/docs changes.
-8. Tag and publish with either the GitHub Actions release workflow or `./scripts/release.sh vX.Y.Z`.
-9. Verify the GitHub release and Homebrew install path.
+1. Confirm the release version (SemVer scope of the merged changes).
+2. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` with the bullets.
+3. Build artifacts (`./scripts/build-release.sh vX.Y.Z`) and bump the in-repo
+   formula (`./scripts/update-brew-formula.sh --version vX.Y.Z`) so it ships in the PR.
+4. Run `make test`; smoke-test a built binary's `--version`.
+5. Sanity-check release notes with `./scripts/release-notes.sh vX.Y.Z`.
+6. Open a release PR and merge it — CI tags and publishes the release.
+7. After CI publishes, verify the GitHub release, then update and push the tap:
+   `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`
+   and commit + push `~/Developer/homebrew-tap`.
+8. Verify the Homebrew install path.
 
 When CLI behavior changes, also update `skills/things/SKILL.md` and the mirrored `../agent-scripts/archived-skills/things/SKILL.md` if that mirror exists.

--- a/.codex/skills/release-flow/references/release-flow.md
+++ b/.codex/skills/release-flow/references/release-flow.md
@@ -43,36 +43,20 @@ Move `CHANGELOG.md` entries out of `Unreleased` into:
 
 The GitHub release body must be only the bullets for that version. `./scripts/release-notes.sh vX.Y.Z` is the source of truth.
 
-## Homebrew Formula
+## Homebrew Formula — generate from RELEASED checksums only
 
-Update the formula after artifacts exist:
-
-```sh
-./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap
-```
-
-Validate:
-
-```sh
-rg -n 'version "|download/v|sha256' Formula/things3-cli.rb ~/Developer/homebrew-tap/Formula/things3-cli.rb
-```
-
-After the GitHub release is live, verify install/upgrade from the tap when practical:
-
-```sh
-brew update
-brew reinstall ossianhempel/tap/things3-cli
-things --version
-```
-
-Do not claim Homebrew is ready until the formula references the released tag and tarball checksums.
+The release tarballs are built by CI, and the build is **not** byte-reproducible:
+a locally built tarball gets a different sha256 than the one CI publishes. So the
+formula must reference the **released** artifacts' checksums, which means the
+formula is generated **after** the GitHub release exists — never bumped inside the
+release PR with local checksums. See the agent-driven step below.
 
 ## Publishing
 
 Publishing is automated. Do **not** tag by hand and do **not** run the local
 publish path for normal releases. Instead:
 
-1. Land the changelog + formula bump on `main` via a release PR.
+1. Land the changelog on `main` via a release PR (no formula bump in this PR).
 2. On merge, `.github/workflows/release.yml` detects the new `## [X.Y.Z]`
    CHANGELOG section, tags `vX.Y.Z` at the merge commit, runs tests, builds
    artifacts, generates notes, and publishes `things3-cli vX.Y.Z`. The workflow
@@ -83,20 +67,28 @@ publish path for normal releases. Instead:
 The legacy `git tag … && git push origin vX.Y.Z` and `./scripts/release.sh`
 paths still work but are not the standard flow.
 
-## Homebrew Tap (agent-driven, after the release is live)
+## Homebrew formulas (agent-driven, after the release is live)
 
-CI does not touch the tap. Once the GitHub release exists (so the released
-tarballs are downloadable and their checksums are final), the agent updates and
-pushes the tap:
+CI does not touch any formula. Once the GitHub release exists, pull the
+**published** checksums and regenerate both the tap formula and the in-repo
+`Formula/things3-cli.rb` from them:
 
 ```sh
+gh release download vX.Y.Z -p checksums.txt -O dist/checksums.txt --clobber
 ./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap
+# sanity: these must equal the released checksums.txt
+rg -n 'sha256' Formula/things3-cli.rb ~/Developer/homebrew-tap/Formula/things3-cli.rb
+
+# tap: commit + push directly
 git -C ~/Developer/homebrew-tap add Formula/things3-cli.rb
 git -C ~/Developer/homebrew-tap commit -m "things3-cli vX.Y.Z"
 git -C ~/Developer/homebrew-tap push
 ```
 
-The maintainer never does this manually — the agent driving the release does.
+The in-repo `Formula/things3-cli.rb` change lands via a small follow-up PR (the
+correct checksums only exist after the release, so they can't be in the release
+PR). The maintainer never does any of this manually — the agent driving the
+release does.
 
 ## Post-Release Verification
 

--- a/.codex/skills/release-flow/references/release-flow.md
+++ b/.codex/skills/release-flow/references/release-flow.md
@@ -69,20 +69,34 @@ Do not claim Homebrew is ready until the formula references the released tag and
 
 ## Publishing
 
-Local publish:
+Publishing is automated. Do **not** tag by hand and do **not** run the local
+publish path for normal releases. Instead:
+
+1. Land the changelog + formula bump on `main` via a release PR.
+2. On merge, `.github/workflows/release.yml` detects the new `## [X.Y.Z]`
+   CHANGELOG section, tags `vX.Y.Z` at the merge commit, runs tests, builds
+   artifacts, generates notes, and publishes `things3-cli vX.Y.Z`. The workflow
+   is idempotent: if the tag already exists it skips.
+3. Manual override only if needed: Actions → Release → Run workflow, enter the
+   version (`workflow_dispatch`).
+
+The legacy `git tag … && git push origin vX.Y.Z` and `./scripts/release.sh`
+paths still work but are not the standard flow.
+
+## Homebrew Tap (agent-driven, after the release is live)
+
+CI does not touch the tap. Once the GitHub release exists (so the released
+tarballs are downloadable and their checksums are final), the agent updates and
+pushes the tap:
 
 ```sh
-./scripts/release.sh vX.Y.Z
+./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap
+git -C ~/Developer/homebrew-tap add Formula/things3-cli.rb
+git -C ~/Developer/homebrew-tap commit -m "things3-cli vX.Y.Z"
+git -C ~/Developer/homebrew-tap push
 ```
 
-CI publish:
-
-```sh
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
-
-The release workflow also runs tests, builds artifacts, generates notes, and publishes the GitHub release.
+The maintainer never does this manually — the agent driving the release does.
 
 ## Post-Release Verification
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,16 @@
 name: Release
 
+# Auto-releases on merge to main: when a commit lands on main that adds a new
+# "## [X.Y.Z]" section to CHANGELOG.md, this workflow tags vX.Y.Z and publishes
+# the GitHub release. It is idempotent — if the tag already exists (e.g. a later
+# CHANGELOG edit that only touches Unreleased), it skips. workflow_dispatch is
+# kept as a manual override.
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+    paths:
+      - CHANGELOG.md
   workflow_dispatch:
     inputs:
       version:
@@ -19,45 +26,66 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version-file: go.mod
+          fetch-depth: 0
 
-      - name: Set version
+      - name: Resolve version
         id: version
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION="v${INPUT_VERSION}"
+            VERSION="${INPUT_VERSION#v}"
           else
-            VERSION="${REF_NAME}"
+            # First semver section in the changelog (skips "## [Unreleased]").
+            VERSION=$(grep -m1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+              | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/')
           fi
-          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            echo "Could not determine release version from CHANGELOG.md or input." >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null \
+            || git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already exists; nothing to release."
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Will release ${TAG}."
+          fi
+
+      - name: Setup Go
+        if: steps.version.outputs.release == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
 
       - name: Run tests
+        if: steps.version.outputs.release == 'true'
         run: go test ./...
 
       - name: Build release artifacts
+        if: steps.version.outputs.release == 'true'
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: ./scripts/build-release.sh "$RELEASE_TAG"
 
       - name: Generate release notes
+        if: steps.version.outputs.release == 'true'
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: ./scripts/release-notes.sh "$RELEASE_TAG" > dist/release-notes.md
 
       - name: Publish GitHub release
+        if: steps.version.outputs.release == 'true'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           name: things3-cli ${{ steps.version.outputs.tag }}
           body_path: dist/release-notes.md
           files: |

--- a/Formula/things3-cli.rb
+++ b/Formula/things3-cli.rb
@@ -6,10 +6,10 @@ class Things3Cli < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/ossianhempel/things3-cli/releases/download/v0.3.0/things-0.3.0-darwin-arm64.tar.gz"
-      sha256 "4a87d9544f3a1357c1b7a335a3432bd2865a7f3181ae211260e1484ec3dd48b0"
+      sha256 "a6464403832457a935d7b7131d358802d5b751f4c7d25a06725b7bd3dad4e68f"
     else
       url "https://github.com/ossianhempel/things3-cli/releases/download/v0.3.0/things-0.3.0-darwin-amd64.tar.gz"
-      sha256 "92d074d9d8de81e314b217a3a0f9de507f9ccede182725657bd30a229107e983"
+      sha256 "235dc9f0a60499d392457114a52b83d5643045ee1020d9f3fa0a97444c6a4197"
     end
   end
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,33 +7,51 @@ read_when:
 
 # Releasing things3-cli
 
+## How releases ship
+
+Tagging and the GitHub release are **automated**. `.github/workflows/release.yml`
+watches `main`: when a merged commit adds a new `## [X.Y.Z]` section to
+`CHANGELOG.md`, CI tags `vX.Y.Z` (at the merge commit), runs tests, builds the
+darwin tarballs, generates the release notes from that changelog section, and
+publishes `things3-cli vX.Y.Z`. The workflow is idempotent — a later CHANGELOG
+edit that only touches **Unreleased** finds the tag already present and skips.
+A `workflow_dispatch` (Actions → Release → Run workflow, enter the version)
+is the manual override.
+
+So nobody tags by hand. The maintainer's only required action is to **merge the
+release PR**. Updating the Homebrew tap is **not** in CI — the agent driving the
+release does it (see below).
+
 ## Guardrails
 
-- Title every GitHub release as `things3-cli <version>`.
+- Title every GitHub release as `things3-cli <version>` (CI does this).
 - Release body = the CHANGELOG bullets for that version only (no extra prose).
 - Do not call a release complete until tests, artifacts, release notes,
   Homebrew formula checksums, GitHub release assets, and the installed binary
   version have been verified.
 
-## Checklist
+## Checklist (the release PR)
 
-- [ ] Confirm you are on `main`, the working tree is clean or only contains the
-      intended release edits, and the next version matches SemVer scope.
-- [ ] Update `CHANGELOG.md`: move items from **Unreleased** into a new version section with today’s date.
+- [ ] Confirm the next version matches SemVer scope for the merged changes.
+- [ ] Update `CHANGELOG.md`: add a new `## [X.Y.Z] - YYYY-MM-DD` section with
+      the bullets for this release.
+- [ ] Bump the in-repo Homebrew formula so it ships in the same PR:
+  `./scripts/build-release.sh vX.Y.Z` then
+  `./scripts/update-brew-formula.sh --version vX.Y.Z` (writes `Formula/things3-cli.rb`).
 - [ ] Run tests: `make test`.
-- [ ] Build release artifacts: `./scripts/build-release.sh vX.Y.Z`.
 - [ ] Smoke-test an artifact binary and confirm `things --version` reports `vX.Y.Z`.
-- [ ] Update Homebrew formula:
+- [ ] Sanity-check release notes: `./scripts/release-notes.sh vX.Y.Z`
+      (should output only the changelog bullets).
+- [ ] Open the PR and merge it. CI tags and publishes the release automatically.
+
+## Checklist (after CI publishes — the agent does this, not the maintainer)
+
+- [ ] Confirm the GitHub release `things3-cli vX.Y.Z` is live with both darwin
+      tarballs and `checksums.txt` attached, and the body is the changelog bullets.
+- [ ] Update and push the Homebrew tap (the released tarballs must already exist
+      so the checksums resolve):
   `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`
-  (commits to `Formula/` and copies into the tap repo).
-- [ ] Verify `Formula/things3-cli.rb` and the tap formula point at the new
-      release URLs and checksums.
-- [ ] Generate release notes: `./scripts/release-notes.sh vX.Y.Z` (should output only the changelog bullets).
-- [ ] Commit the changelog/formula/docs changes.
-- [ ] Tag the release: `git tag vX.Y.Z` then `git push origin vX.Y.Z`.
-- [ ] Create the GitHub release:
-  - Option A (local): `./scripts/release.sh vX.Y.Z`
-  - Option B (CI): push the tag and let `.github/workflows/release.yml` publish the release
-- [ ] Verify the GitHub release title, notes, and assets match the guardrails.
+  then commit and push the tap repo.
+- [ ] Verify the tap formula points at the new release URLs and checksums.
 - [ ] Verify Homebrew install or reinstall from `ossianhempel/tap/things3-cli`
       and confirm `things --version`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,8 +19,14 @@ A `workflow_dispatch` (Actions → Release → Run workflow, enter the version)
 is the manual override.
 
 So nobody tags by hand. The maintainer's only required action is to **merge the
-release PR**. Updating the Homebrew tap is **not** in CI — the agent driving the
-release does it (see below).
+release PR**. Both Homebrew formulas (in-repo `Formula/` and the tap) are updated
+**after** the release publishes — by the agent, not in CI (see below).
+
+> **Why the formula is updated after the release, not in the PR:** the release
+> tarballs are built by CI, and the build is **not** byte-reproducible (a locally
+> built tarball gets a different sha256 than CI's). So the formula must reference
+> the **released** artifacts' checksums. Never put locally built checksums in the
+> formula — they will not match what users download.
 
 ## Guardrails
 
@@ -34,12 +40,11 @@ release does it (see below).
 
 - [ ] Confirm the next version matches SemVer scope for the merged changes.
 - [ ] Update `CHANGELOG.md`: add a new `## [X.Y.Z] - YYYY-MM-DD` section with
-      the bullets for this release.
-- [ ] Bump the in-repo Homebrew formula so it ships in the same PR:
-  `./scripts/build-release.sh vX.Y.Z` then
-  `./scripts/update-brew-formula.sh --version vX.Y.Z` (writes `Formula/things3-cli.rb`).
+      the bullets for this release. (Do **not** bump the formula here — see the
+      note above.)
 - [ ] Run tests: `make test`.
-- [ ] Smoke-test an artifact binary and confirm `things --version` reports `vX.Y.Z`.
+- [ ] Build and smoke-test locally: `./scripts/build-release.sh vX.Y.Z` then
+      confirm the built binary's `things --version` reports `vX.Y.Z`.
 - [ ] Sanity-check release notes: `./scripts/release-notes.sh vX.Y.Z`
       (should output only the changelog bullets).
 - [ ] Open the PR and merge it. CI tags and publishes the release automatically.
@@ -48,10 +53,15 @@ release does it (see below).
 
 - [ ] Confirm the GitHub release `things3-cli vX.Y.Z` is live with both darwin
       tarballs and `checksums.txt` attached, and the body is the changelog bullets.
-- [ ] Update and push the Homebrew tap (the released tarballs must already exist
-      so the checksums resolve):
+- [ ] Generate both formulas from the **released** checksums (download the
+      published checksums first so they match what users get):
+  `gh release download vX.Y.Z -p checksums.txt -O dist/checksums.txt --clobber`
+  then
   `./scripts/update-brew-formula.sh --version vX.Y.Z --tap-dir ~/Developer/homebrew-tap`
-  then commit and push the tap repo.
-- [ ] Verify the tap formula points at the new release URLs and checksums.
+  (writes `Formula/things3-cli.rb` and copies it into the tap).
+- [ ] Confirm `Formula/things3-cli.rb` and the tap formula sha256s equal the
+      released `checksums.txt` values.
+- [ ] Commit and push the tap repo; open a follow-up PR for the in-repo
+      `Formula/things3-cli.rb` (its checksums change is too late for the release PR).
 - [ ] Verify Homebrew install or reinstall from `ossianhempel/tap/things3-cli`
       and confirm `things --version`.


### PR DESCRIPTION
Follow-up to the v0.3.0 release. Two things that didn't make it onto `main`:

## 1. Release automation (was lost from PR #21)
PR #21 merged at an earlier head, so the auto-release workflow + docs never
landed on `main`. This re-applies them:
- `.github/workflows/release.yml` auto-releases on merge to `main` when a new
  `## [X.Y.Z]` CHANGELOG section appears (idempotent; `workflow_dispatch` override).

This also explains why v0.3.0 didn't auto-release — the new workflow wasn't on
main yet; v0.3.0 was published via `workflow_dispatch` on the old workflow.

## 2. Correct v0.3.0 formula checksums + fix the flow
The v0.3.0 release PR put **locally built** checksums in `Formula/things3-cli.rb`.
CI's tarballs are **not byte-reproducible**, so those sha256s didn't match the
published artifacts. Corrected to the released values (already live in the tap).

Flow fix so it can't recur: the formula is now generated from the **released**
checksums *after* the GitHub release exists, never bumped in the release PR.
Updated `RELEASING.md`, the release-flow skill, and its reference.

## Notes
- Does not touch `CHANGELOG.md`, so merging this will not trigger a release.
- v0.3.0 itself is live and `brew reinstall ossianhempel/tap/things3-cli` →
  `things --version` reports v0.3.0 (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)