### PR TITLE
fix: allow clearing deadline, "when", and tags with explicit empty values

### DIFF
--- a/doc/man/things.1.md
+++ b/doc/man/things.1.md
@@ -324,20 +324,22 @@ This Evening.
   Set the when field of a todo. Possible values: today, tomorrow,
   evening, someday, a date string, or a date time string. Including a time
   adds a reminder for that time. The time component is ignored if someday
-  is specified. This field cannot be updated on repeating todo.
+  is specified. An empty string (`--when=""`) clears the scheduled date.
+  This field cannot be updated on repeating todo.
   Optional.
 
 *--later*
   Move the todo to This Evening (alias for `--when=evening`). Optional.
 
 *--deadline=DATE*
-  The deadline to apply to the todo. This field cannot be updated on
-  repeating todo. Optional.
+  The deadline to apply to the todo. An empty string (`--deadline=""`)
+  clears the deadline. This field cannot be updated on repeating todo.
+  Optional.
 
 *--tags=TAG1[,TAG2,TAG3...]*
   Comma separated strings corresponding to the titles of tags. Replaces
-  all current tags. Does not apply a tag if the specified tag doesn't
-  exist. Optional.
+  all current tags. An empty string (`--tags=""`) removes all tags. Does
+  not apply a tag if the specified tag doesn't exist. Optional.
 
 *--add-tags=TAG1[,TAG2,TAG3...]*
   Comma separated strings corresponding to the titles of tags. Adds the
@@ -642,15 +644,17 @@ precedence over the `--notes=` option.
   Set the when field of a project. Possible values: today, tomorrow,
   evening, someday, a date string, or a date time string. Including a time
   adds a reminder for that time. The time component is ignored if someday
-  is specified. Optional.
+  is specified. An empty string (`--when=""`) clears the scheduled date.
+  Optional.
 
 *--deadline=DATE*
-  The deadline to apply to the project. Optional.
+  The deadline to apply to the project. An empty string (`--deadline=""`)
+  clears the deadline. Optional.
 
 *--tags=TAG1[,TAG2,TAG3...]*
   Comma separated strings corresponding to the titles of tags. Replaces
-  all current tags. Does not apply a tag if the specified tag doesn't
-  exist. Optional.
+  all current tags. An empty string (`--tags=""`) removes all tags. Does
+  not apply a tag if the specified tag doesn't exist. Optional.
 
 *--add-tags=TAG1[,TAG2,TAG3...]*
   Comma separated strings corresponding to the titles of tags. Adds the

--- a/internal/cli/helptext.go
+++ b/internal/cli/helptext.go
@@ -2061,7 +2061,8 @@ OPTIONS
     Set the when field of a todo. Possible values: today, tomorrow,
     evening, someday, a date string, or a date time string. Including a time
     adds a reminder for that time. The time component is ignored if someday
-    is specified. This field cannot be updated on repeating todo.
+    is specified. An empty string ({{BT}}--when=""{{BT}}) clears the
+    scheduled date. This field cannot be updated on repeating todo.
     Optional.
 
   --later
@@ -2075,13 +2076,14 @@ OPTIONS
     Skip verification of when updates against the Things database.
 
   --deadline=DATE
-    The deadline to apply to the todo. This field cannot be updated on
-    repeating todo. Optional.
+    The deadline to apply to the todo. An empty string
+    ({{BT}}--deadline=""{{BT}}) clears the deadline. This field cannot be
+    updated on repeating todo. Optional.
 
   --tags=TAG1[,TAG2,TAG3...]
     Comma separated strings corresponding to the titles of tags. Replaces
-    all current tags. Does not apply a tag if the specified tag doesn't
-    exist. Optional.
+    all current tags. An empty string ({{BT}}--tags=""{{BT}}) removes all
+    tags. Does not apply a tag if the specified tag doesn't exist. Optional.
 
   --add-tags=TAG1[,TAG2,TAG3...]
     Comma separated strings corresponding to the titles of tags. Adds the
@@ -2424,15 +2426,17 @@ OPTIONS
     Set the when field of a project. Possible values: today, tomorrow,
     evening, someday, a date string, or a date time string. Including a time
     adds a reminder for that time. The time component is ignored if someday
-    is specified. Optional.
+    is specified. An empty string ({{BT}}--when=""{{BT}}) clears the
+    scheduled date. Optional.
 
   --deadline=DATE
-    The deadline to apply to the project. Optional.
+    The deadline to apply to the project. An empty string
+    ({{BT}}--deadline=""{{BT}}) clears the deadline. Optional.
 
   --tags=TAG1[,TAG2,TAG3...]
     Comma separated strings corresponding to the titles of tags. Replaces
-    all current tags. Does not apply a tag if the specified tag doesn't
-    exist. Optional.
+    all current tags. An empty string ({{BT}}--tags=""{{BT}}) removes all
+    tags. Does not apply a tag if the specified tag doesn't exist. Optional.
 
   --add-tags=TAG1[,TAG2,TAG3...]
     Comma separated strings corresponding to the titles of tags. Adds the

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -47,6 +47,9 @@ func NewUpdateCommand(app *App) *cobra.Command {
 				return err
 			}
 			opts.NotesSet = cmd.Flags().Changed("notes")
+			opts.WhenSet = cmd.Flags().Changed("when")
+			opts.DeadlineSet = cmd.Flags().Changed("deadline")
+			opts.TagsSet = cmd.Flags().Changed("tags")
 			verifyWhen := resolveWhenValue(opts.When, opts.Later)
 			verifyWhenEnabled := verifyWhen != "" && !noVerify && !app.DryRun
 			guardEvening := strings.EqualFold(verifyWhen, "evening") && !allowNonToday
@@ -374,10 +377,10 @@ func NewUpdateCommand(app *App) *cobra.Command {
 	flags.StringVar(&opts.Notes, "notes", "", "Replace notes")
 	flags.StringVar(&opts.PrependNotes, "prepend-notes", "", "Prepend to notes")
 	flags.StringVar(&opts.AppendNotes, "append-notes", "", "Append to notes")
-	flags.StringVar(&opts.When, "when", "", "When to schedule the todo")
+	flags.StringVar(&opts.When, "when", "", "When to schedule the todo (empty string clears the date)")
 	flags.BoolVar(&opts.Later, "later", false, "Move the todo to Later")
-	flags.StringVar(&opts.Deadline, "deadline", "", "Deadline for the todo")
-	flags.StringVar(&opts.Tags, "tags", "", "Replace tags")
+	flags.StringVar(&opts.Deadline, "deadline", "", "Deadline for the todo (empty string clears it)")
+	flags.StringVar(&opts.Tags, "tags", "", "Replace tags (empty string clears all tags)")
 	flags.StringVar(&opts.AddTags, "add-tags", "", "Add tags")
 	flags.BoolVar(&opts.Completed, "completed", false, "Mark the todo completed")
 	flags.BoolVar(&opts.Canceled, "canceled", false, "Mark the todo canceled")
@@ -411,13 +414,13 @@ func hasTodoUpdateChanges(opts things.UpdateOptions, rawInput string) bool {
 	if opts.Notes != "" || opts.NotesSet || opts.PrependNotes != "" || opts.AppendNotes != "" {
 		return true
 	}
-	if opts.When != "" || opts.Later {
+	if opts.When != "" || opts.WhenSet || opts.Later {
 		return true
 	}
-	if opts.Deadline != "" {
+	if opts.Deadline != "" || opts.DeadlineSet {
 		return true
 	}
-	if opts.Tags != "" || opts.AddTags != "" {
+	if opts.Tags != "" || opts.TagsSet || opts.AddTags != "" {
 		return true
 	}
 	if opts.Completed || opts.Canceled {

--- a/internal/cli/update_project.go
+++ b/internal/cli/update_project.go
@@ -26,6 +26,9 @@ func NewUpdateProjectCommand(app *App) *cobra.Command {
 				return err
 			}
 			opts.NotesSet = cmd.Flags().Changed("notes")
+			opts.WhenSet = cmd.Flags().Changed("when")
+			opts.DeadlineSet = cmd.Flags().Changed("deadline")
+			opts.TagsSet = cmd.Flags().Changed("tags")
 
 			token, err := resolveAuthToken(app, opts.AuthToken)
 			if err != nil {
@@ -47,9 +50,9 @@ func NewUpdateProjectCommand(app *App) *cobra.Command {
 	flags.StringVar(&opts.Notes, "notes", "", "Replace notes")
 	flags.StringVar(&opts.PrependNotes, "prepend-notes", "", "Prepend to notes")
 	flags.StringVar(&opts.AppendNotes, "append-notes", "", "Append to notes")
-	flags.StringVar(&opts.When, "when", "", "When to schedule the project")
-	flags.StringVar(&opts.Deadline, "deadline", "", "Deadline for the project")
-	flags.StringVar(&opts.Tags, "tags", "", "Replace tags")
+	flags.StringVar(&opts.When, "when", "", "When to schedule the project (empty string clears the date)")
+	flags.StringVar(&opts.Deadline, "deadline", "", "Deadline for the project (empty string clears it)")
+	flags.StringVar(&opts.Tags, "tags", "", "Replace tags (empty string clears all tags)")
 	flags.StringVar(&opts.AddTags, "add-tags", "", "Add tags")
 	flags.StringVar(&opts.AreaID, "area-id", "", "Area ID to move to")
 	flags.StringVar(&opts.Area, "area", "", "Area to move to")

--- a/internal/cli/update_project_test.go
+++ b/internal/cli/update_project_test.go
@@ -56,6 +56,32 @@ func TestUpdateProjectCommandWithAuthAndID(t *testing.T) {
 	}
 }
 
+func TestUpdateProjectCommandEmptyValuesClearFields(t *testing.T) {
+	launcher := &recordLauncher{}
+	app := &App{
+		In:       strings.NewReader(""),
+		Out:      &bytes.Buffer{},
+		Err:      &bytes.Buffer{},
+		Launcher: launcher,
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"update-project", "--auth-token", "tok", "--id", "123", "--when=", "--deadline=", "--tags="})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	url := requireOpenURL(t, launcher)
+	for _, param := range []string{"when=&", "deadline=&", "tags=&"} {
+		if !strings.Contains(url, param) {
+			t.Fatalf("expected %q in url, got %q", param, url)
+		}
+	}
+}
+
 func TestUpdateProjectCommandAddTags(t *testing.T) {
 	launcher := &recordLauncher{}
 	app := &App{

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -80,6 +80,32 @@ func TestUpdateCommandLaterFlag(t *testing.T) {
 	}
 }
 
+func TestUpdateCommandEmptyValuesClearFields(t *testing.T) {
+	launcher := &recordLauncher{}
+	app := &App{
+		In:       strings.NewReader(""),
+		Out:      &bytes.Buffer{},
+		Err:      &bytes.Buffer{},
+		Launcher: launcher,
+	}
+
+	root := NewRoot(app)
+	root.SetArgs([]string{"update", "--auth-token", "tok", "--id", "123", "--when=", "--deadline=", "--tags=", "--no-verify"})
+	root.SetOut(app.Out)
+	root.SetErr(app.Err)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	url := requireOpenURL(t, launcher)
+	for _, param := range []string{"when=&", "deadline=&", "tags=&"} {
+		if !strings.Contains(url, param) {
+			t.Fatalf("expected %q in url, got %q", param, url)
+		}
+	}
+}
+
 func TestUpdateCommandRejectsUnsafeTitle(t *testing.T) {
 	launcher := &recordLauncher{}
 	app := &App{

--- a/internal/things/update.go
+++ b/internal/things/update.go
@@ -15,9 +15,12 @@ type UpdateOptions struct {
 	PrependNotes             string
 	AppendNotes              string
 	When                     string
+	WhenSet                  bool
 	Later                    bool
 	Deadline                 string
+	DeadlineSet              bool
 	Tags                     string
+	TagsSet                  bool
 	AddTags                  string
 	Completed                bool
 	Canceled                 bool
@@ -116,9 +119,11 @@ func BuildUpdateURL(opts UpdateOptions, rawInput string) (string, error) {
 		params = append(params, "when="+URLEncode(opts.When))
 	} else if opts.Later {
 		params = append(params, "when=evening")
+	} else if opts.WhenSet {
+		params = append(params, "when=")
 	}
 
-	if opts.Deadline != "" {
+	if opts.Deadline != "" || opts.DeadlineSet {
 		params = append(params, "deadline="+URLEncode(opts.Deadline))
 	}
 
@@ -126,7 +131,7 @@ func BuildUpdateURL(opts UpdateOptions, rawInput string) (string, error) {
 		params = append(params, "reveal=true")
 	}
 
-	if opts.Tags != "" {
+	if opts.Tags != "" || opts.TagsSet {
 		params = append(params, "tags="+URLEncode(opts.Tags))
 	}
 

--- a/internal/things/update_project.go
+++ b/internal/things/update_project.go
@@ -11,8 +11,11 @@ type UpdateProjectOptions struct {
 	PrependNotes   string
 	AppendNotes    string
 	When           string
+	WhenSet        bool
 	Deadline       string
+	DeadlineSet    bool
 	Tags           string
+	TagsSet        bool
 	AddTags        string
 	AreaID         string
 	Area           string
@@ -68,11 +71,11 @@ func BuildUpdateProjectURL(opts UpdateProjectOptions, rawInput string) (string, 
 		params = append(params, "duplicate=true")
 	}
 
-	if opts.When != "" {
+	if opts.When != "" || opts.WhenSet {
 		params = append(params, "when="+URLEncode(opts.When))
 	}
 
-	if opts.Deadline != "" {
+	if opts.Deadline != "" || opts.DeadlineSet {
 		params = append(params, "deadline="+URLEncode(opts.Deadline))
 	}
 
@@ -88,7 +91,7 @@ func BuildUpdateProjectURL(opts UpdateProjectOptions, rawInput string) (string, 
 		params = append(params, "reveal=true")
 	}
 
-	if opts.Tags != "" {
+	if opts.Tags != "" || opts.TagsSet {
 		params = append(params, "tags="+URLEncode(opts.Tags))
 	}
 

--- a/internal/things/update_project_test.go
+++ b/internal/things/update_project_test.go
@@ -90,6 +90,31 @@ func TestBuildUpdateProjectURLAddTags(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateProjectURLEmptySetValuesClearFields(t *testing.T) {
+	opts := UpdateProjectOptions{AuthToken: "tok", ID: "id", WhenSet: true, DeadlineSet: true, TagsSet: true}
+	url, err := BuildUpdateProjectURL(opts, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, param := range []string{"when=&", "deadline=&", "tags=&"} {
+		if !contains(url, param) {
+			t.Fatalf("expected %q in %q", param, url)
+		}
+	}
+}
+
+func TestBuildUpdateProjectURLOmitsUnsetEmptyFields(t *testing.T) {
+	url, err := BuildUpdateProjectURL(UpdateProjectOptions{AuthToken: "tok", ID: "id", Notes: "Notes"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, param := range []string{"when=", "deadline=", "tags="} {
+		if contains(url, param) {
+			t.Fatalf("did not expect %q in %q", param, url)
+		}
+	}
+}
+
 func TestBuildUpdateProjectURLTrailingAmpersand(t *testing.T) {
 	url, err := BuildUpdateProjectURL(UpdateProjectOptions{AuthToken: "tok", ID: "id", Notes: "Notes"}, "")
 	if err != nil {

--- a/internal/things/update_test.go
+++ b/internal/things/update_test.go
@@ -106,6 +106,45 @@ func TestBuildUpdateURLWhenOverridesLater(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateURLEmptySetValuesClearFields(t *testing.T) {
+	opts := UpdateOptions{AuthToken: "tok", ID: "id", WhenSet: true, DeadlineSet: true, TagsSet: true}
+	url, err := BuildUpdateURL(opts, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, param := range []string{"when=&", "deadline=&", "tags=&"} {
+		if !contains(url, param) {
+			t.Fatalf("expected %q in %q", param, url)
+		}
+	}
+}
+
+func TestBuildUpdateURLOmitsUnsetEmptyFields(t *testing.T) {
+	url, err := BuildUpdateURL(UpdateOptions{AuthToken: "tok", ID: "id", Notes: "Notes"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, param := range []string{"when=", "deadline=", "tags="} {
+		if contains(url, param) {
+			t.Fatalf("did not expect %q in %q", param, url)
+		}
+	}
+}
+
+func TestBuildUpdateURLLaterOverridesEmptyWhen(t *testing.T) {
+	opts := UpdateOptions{AuthToken: "tok", ID: "id", Later: true, WhenSet: true}
+	url, err := BuildUpdateURL(opts, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(url, "when=evening") {
+		t.Fatalf("expected when=evening in %q", url)
+	}
+	if contains(url, "when=&") {
+		t.Fatalf("did not expect empty when in %q", url)
+	}
+}
+
 func TestBuildUpdateURLTrailingAmpersand(t *testing.T) {
 	url, err := BuildUpdateURL(UpdateOptions{AuthToken: "tok", ID: "id", Notes: "Notes"}, "")
 	if err != nil {

--- a/share/man/man1/things.1
+++ b/share/man/man1/things.1
@@ -390,18 +390,21 @@ length: 10,000 characters\. Optional\.
 Set the when field of a todo\. Possible values: today, tomorrow,
 evening, someday, a date string, or a date time string\. Including a time
 adds a reminder for that time\. The time component is ignored if someday
-is specified\. This field cannot be updated on repeating todo\.
+is specified\. An empty string (\fB--when=""\fR) clears the scheduled
+date\. This field cannot be updated on repeating todo\.
 Optional\.
 .LP
 .TP
 \fI\-\-deadline\[eq]DATE\fP
-The deadline to apply to the todo\. This field cannot be updated on
+The deadline to apply to the todo\. An empty string (\fB--deadline=""\fR)
+clears the deadline\. This field cannot be updated on
 repeating todo\. Optional\.
 .LP
 .TP
 \fI\-\-tags\[eq]TAG1\[lB],TAG2,TAG3\.\.\.\[rB]\fP
 Comma separated strings corresponding to the titles of tags\. Replaces
-all current tags\. Does not apply a tag if the specified tag doesn\[cq]t
+all current tags\. An empty string (\fB--tags=""\fR) removes all tags\.
+Does not apply a tag if the specified tag doesn\[cq]t
 exist\. Optional\.
 .LP
 .TP
@@ -814,16 +817,19 @@ length: 10,000 characters\. Optional\.
 Set the when field of a project\. Possible values: today, tomorrow,
 evening, someday, a date string, or a date time string\. Including a time
 adds a reminder for that time\. The time component is ignored if someday
-is specified\. Optional\.
+is specified\. An empty string (\fB--when=""\fR) clears the scheduled
+date\. Optional\.
 .LP
 .TP
 \fI\-\-deadline\[eq]DATE\fP
-The deadline to apply to the project\. Optional\.
+The deadline to apply to the project\. An empty string
+(\fB--deadline=""\fR) clears the deadline\. Optional\.
 .LP
 .TP
 \fI\-\-tags\[eq]TAG1\[lB],TAG2,TAG3\.\.\.\[rB]\fP
 Comma separated strings corresponding to the titles of tags\. Replaces
-all current tags\. Does not apply a tag if the specified tag doesn\[cq]t
+all current tags\. An empty string (\fB--tags=""\fR) removes all tags\.
+Does not apply a tag if the specified tag doesn\[cq]t
 exist\. Optional\.
 .LP
 .TP

--- a/skills/things/SKILL.md
+++ b/skills/things/SKILL.md
@@ -25,6 +25,7 @@ Write (URL scheme)
 - `things add-project "Project title" --area "Area Name"`
 - `things update --id <uuid> --notes "Updated notes"`
 - Clear notes by passing an explicit empty notes value: `things update --id <uuid> --notes ""`
+- Clear a deadline, scheduled date, or all tags the same way: `things update --id <uuid> --deadline=""`, `--when=""`, or `--tags=""` (also works for `update-project`)
 - Checklist status by exact title: `things update --id <uuid> --complete-checklist-item "Step 1"` or `things update --id <uuid> --incomplete-checklist-item "Step 1"`
 - Bulk update (preview then apply): `things update --query 'tag:work' --dry-run` then `things update --query 'tag:work' --yes --tags "Work"`
 - `things update-project --id <uuid> "New project title"`
@@ -67,7 +68,7 @@ Auth + permissions
 - Update `--when/--later` is verified against the database by default; use `--no-verify` to skip verification.
 - `--later` / `--when=evening` refuses to move tasks that are already scheduled for a non-today date; use `--allow-non-today` to override.
 - Titles that look like flag assignments (e.g. `tag=work`) are rejected; pass `--allow-unsafe-title` to keep them as the title.
-- For updates, an explicitly provided empty `--notes ""` clears notes; omitting `--notes` leaves notes unchanged.
+- For updates, an explicitly provided empty value clears the field (`--notes ""`, `--deadline=""`, `--when=""`, `--tags=""`); omitting the flag leaves the field unchanged.
 - Delete commands prompt for confirmation when interactive; pass `--confirm` for single deletes in non-interactive scripts. Query deletes require `--confirm=delete` or `--yes`.
 - Bulk update/delete write an action log; use `things undo` to revert the last bulk update or trash.
 


### PR DESCRIPTION
## Summary

`things update --id <uuid> --deadline=""` was a silent no-op. The URL builders only emitted params with non-empty values, but the Things URL scheme treats a bare `deadline=` / `when=` / `tags=` as "clear the field". The only way to actually clear a deadline was hand-crafting a raw `things:///update?...&deadline=` URL yourself.

The fix mirrors the existing `NotesSet` pattern: new `WhenSet` / `DeadlineSet` / `TagsSet` fields wired from `flags.Changed(...)`. An explicit empty value clears the field. An omitted flag leaves it untouched.

- Applies to both `update` and `update-project`
- `--later` still wins over an explicit empty `--when` (consistent with `resolveWhenValue`)
- `hasTodoUpdateChanges` now counts explicitly-empty flags as changes
- Docs synced: help text, flag descriptions, man page (source + rendered), `skills/things/SKILL.md`

## Testing

`make test` passes (unit + integration).

New unit tests: builders emit `when=&` / `deadline=&` / `tags=&` only when the flag is explicitly set, omit them when unset, and `--later` beats an empty `--when`. Plus CLI-level tests for both `update` and `update-project`.

Also verified live against the real Things 3 app on macOS: created a temp todo with when/deadline/tags set, cleared each field via `--when=""` / `--deadline=""` / `--tags=""`, checked the database after each step, then deleted the test todo.

No new permissions; uses the existing URL scheme auth token.